### PR TITLE
meta-hp: udev-extraconf: add systemd tag to touchscreen rule

### DIFF
--- a/meta-hp/recipes-core/udev/udev-extraconf/tenderloin.rules
+++ b/meta-hp/recipes-core/udev/udev-extraconf/tenderloin.rules
@@ -1,2 +1,2 @@
 # modalias for touch screen doesn't match the common rule so we add it statically here
-SUBSYSTEM=="input", KERNEL=="event[0-9]*", ATTRS{modalias}=="input:b0006v0001p0001e0001-e0,3,kra30,35,36,39,3A,mlsfw", SYMLINK+="input/touchscreen0"
+SUBSYSTEM=="input", KERNEL=="event[0-9]*", ATTRS{modalias}=="input:b0006v0001p0001e0001-e0,3,kra30,35,36,39,3A,mlsfw", TAG+="systemd", SYMLINK+="input/touchscreen0"


### PR DESCRIPTION
Needed to start LunaSysMgr after touchscreen device is ready.
Signed-off-by: Nikolay Nizov <nizovn@gmail.com>