### PR TITLE
android-system: restore mount for hal-droid

### DIFF
--- a/meta-android/recipes-core/android-system/android-system/pre-start.sh
+++ b/meta-android/recipes-core/android-system/android-system/pre-start.sh
@@ -55,7 +55,7 @@ mount_bind_ro /system $LXC_ROOTFS_PATH/system
 mount_bind_ro /system/vendor $LXC_ROOTFS_PATH/vendor
 mount_bind_ro /firmware $LXC_ROOTFS_PATH/firmware
 mount_bind_ro /system/etc $LXC_ROOTFS_PATH/etc
-# mount_bind_ro /usr/libexec/hal-droid $LXC_ROOTFS_PATH/hal-hybris
+mount_bind_ro /usr/libexec/hal-droid $LXC_ROOTFS_PATH/hal-hybris
 
 # usage existing /data directory
 mkdir -p /data


### PR DESCRIPTION
This mount is necessary to have the pvr module for maguro.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>