### PR TITLE
android-system-image: fix builds that don't have overlay-libs

### DIFF
--- a/meta-android/recipes-core/android-system-image/android-system-image.inc
+++ b/meta-android/recipes-core/android-system-image/android-system-image.inc
@@ -21,6 +21,7 @@ do_install() {
     install -d ${D}${libexecdir}/hal-droid/system/symbols
     cp -rv ${WORKDIR}/symbols ${D}${libexecdir}/hal-droid/system
 
+    mkdir -p ${WORKDIR}/overlay-libs
     cp -rpv ${WORKDIR}/overlay-libs ${D}${libexecdir}/hal-droid
     for i in ${WORKDIR}/overlay-libs/*.so; do
         [ ! -f ${D}${libexecdir}/hal-droid/system/lib/$(basename $i) ] && cp $i ${D}${libexecdir}/hal-droid/system/lib


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>