### PR TITLE
android-system-image-tenderloin: update Android image

### DIFF
--- a/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin_20170714-1.bb
+++ b/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin_20170714-1.bb
@@ -17,6 +17,6 @@ INSANE_SKIP_${PN} += "ldflags"
 # Fixing QA errors for binaries with relocations in .text
 INSANE_SKIP_${PN} += "textrel"
 
-SRC_URI = "http://build.webos-ports.org/halium-wop-12.1/hal-droid-wop-12.1-20170708-tenderloin.tar.bz2"
-SRC_URI[md5sum] = "be29055be38fc540f92dc5b1664e8890"
-SRC_URI[sha256sum] = "ce8fe227a888d59426406ce2baf6374bc44cc6092b429c997dfe1e9c15b884cf"
+SRC_URI = "http://build.webos-ports.org/halium-wop-12.1/hal-droid-wop-12.1-20170714-tenderloin.tar.bz2"
+SRC_URI[md5sum] = "c1b91241951904ba4e72227188987efd"
+SRC_URI[sha256sum] = "286e982f34308c2a69fc203f1ed60447040760f7a1b41fd3a81702f0a9cf7aa0"

--- a/meta-hp/recipes-kernel/linux/linux-hp-tenderloin_git.bb
+++ b/meta-hp/recipes-kernel/linux/linux-hp-tenderloin_git.bb
@@ -11,7 +11,7 @@ SRC_URI = " \
 "
 S = "${WORKDIR}/git"
 
-SRCREV = "78c953925961fea4e31e578ce5b5e321d422874a"
+SRCREV = "c300d47f8eee6219e066cba2a58225e6b7b5ef38"
 
 do_compile[depends] += "initramfs-android-image:do_image_complete"
 DEPENDS += "u-boot-mkimage-native initramfs-android-image"


### PR DESCRIPTION
* fix a crash in audio_hw.c when mixer is unknown
* disable input audio profile

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>