### PR TITLE
hammerhead kernel: delay wifi init

### DIFF
--- a/meta-lg/conf/machine/hammerhead.conf
+++ b/meta-lg/conf/machine/hammerhead.conf
@@ -33,6 +33,7 @@ XSERVER = " \
 # Also, include the wlan module for the kernel
 MACHINE_EXTRA_RDEPENDS = " \
     dosfstools \
+    kernel-module-bcmdhd \
 "
 
 # For Nexus 5, we need to build the dtb together with the zImage

--- a/meta-lg/recipes-core/systemd/systemd-machine-units/hammerhead/persist-wifi-mac-addr.sh
+++ b/meta-lg/recipes-core/systemd/systemd-machine-units/hammerhead/persist-wifi-mac-addr.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+if [ -e /persist/wifi/.macaddr ] ; then
+	echo "File /persist/wifi/.macaddr already exists"
+	exit 0
+fi
+
+timeout=10
+while [ ! -e /sys/class/net/wlan0 ] ; do
+	sleep 1
+	if [ "$timeout" -le 0 ]; then
+		echo "Could not persist WiFi mac addr cause the network interface isn't availalbe"
+		exit 0
+	fi
+	timeout=$(($timeout - 1))
+done
+
+mkdir -p /persist/wifi
+chmod 755 /persist/wifi
+# replace plain address by binary hex chars
+wifi_mac="$(sed -e 's/\(..\)[:]\?/\\x\1/g' < /sys/class/net/wlan0/address)"
+echo -ne $wifi_mac > /persist/wifi/.macaddr

--- a/meta-lg/recipes-core/systemd/systemd-machine-units/hammerhead/wifi-macaddr-persister.service
+++ b/meta-lg/recipes-core/systemd/systemd-machine-units/hammerhead/wifi-macaddr-persister.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Saving WiFi MAC Addr on first boot
+After=android-system.service
+Requires=android-system.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/persist-wifi-mac-addr.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-lg/recipes-core/systemd/systemd-machine-units/hammerhead/wifi-module-load.service
+++ b/meta-lg/recipes-core/systemd/systemd-machine-units/hammerhead/wifi-module-load.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Load wifi module
+After=android-system-filesystems.target
+Before=android-system.service
+Conflicts=shutdown.target actdead.target
+
+[Service]
+Type=simple
+RemainAfterExit=yes
+ExecStart=/sbin/modprobe bcmdhd
+ExecStop=/sbin/rmmod bcmdhd
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=basic.target
+

--- a/meta-lg/recipes-core/systemd/systemd-machine-units_1.0.bbappend
+++ b/meta-lg/recipes-core/systemd/systemd-machine-units_1.0.bbappend
@@ -1,6 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI_append_mako = " \
+COMPATIBLE_MACHINE_mako = "mako"
+COMPATIBLE_MACHINE_hammerhead = "hammerhead"
+
+SRC_URI_append = " \
     file://wifi-macaddr-persister.service \
     file://wifi-module-load.service \
     file://persist-wifi-mac-addr.sh \
@@ -8,7 +11,7 @@ SRC_URI_append_mako = " \
     file://hci-smd-enable.sh \
 "
 
-do_install_append_mako() {
+do_install_append() {
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/wifi-macaddr-persister.service ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/hcismd.service ${D}${systemd_unitdir}/system
@@ -19,26 +22,9 @@ do_install_append_mako() {
     install -m 0755 ${WORKDIR}/hci-smd-enable.sh ${D}${bindir}
 }
 
-SYSTEMD_SERVICE_${PN}_mako = " \
+SYSTEMD_SERVICE_${PN} = " \
     wifi-macaddr-persister.service \
     wifi-module-load.service \
     hcismd.service \
 "
 
-
-SRC_URI_append_hammerhead = " \
-    file://hcismd.service \
-    file://hci-smd-enable.sh \
-"
-
-do_install_append_hammerhead() {
-    install -d ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/hcismd.service ${D}${systemd_unitdir}/system
-
-    install -d ${D}${bindir}
-    install -m 0755 ${WORKDIR}/hci-smd-enable.sh ${D}${bindir}
-}
-
-SYSTEMD_SERVICE_${PN}_hammerhead = " \
-    hcismd.service \
-"

--- a/meta-lg/recipes-kernel/linux/linux-lg-hammerhead/defconfig
+++ b/meta-lg/recipes-kernel/linux/linux-lg-hammerhead/defconfig
@@ -1151,7 +1151,7 @@ CONFIG_BT_HIDP=y
 #
 # Bluetooth device drivers
 #
-# CONFIG_BT_HCISMD is not set
+CONFIG_BT_HCISMD=y
 # CONFIG_BT_HCIBTUSB is not set
 # CONFIG_BT_HCIBTSDIO is not set
 # CONFIG_BT_HCIUART is not set
@@ -1489,14 +1489,14 @@ CONFIG_USB_IPHETH=y
 CONFIG_USB_SIERRA_NET=y
 # CONFIG_USB_VL600 is not set
 # CONFIG_MSM_RMNET_USB is not set
-CONFIG_WLAN=y
+CONFIG_WLAN=m
 # CONFIG_USB_ZD1201 is not set
 # CONFIG_USB_NET_RNDIS_WLAN is not set
 # CONFIG_LIBRA_SDIOIF is not set
 # CONFIG_ATH6K_LEGACY_EXT is not set
 # CONFIG_WCNSS_CORE is not set
 # CONFIG_ATH_COMMON is not set
-CONFIG_BCMDHD=y
+CONFIG_BCMDHD=m
 CONFIG_BCM4339=y
 CONFIG_BCMDHD_FW_PATH="/vendor/firmware/fw_bcmdhd.bin"
 CONFIG_BCMDHD_NVRAM_PATH="/system/etc/wifi/bcmdhd.cal"


### PR DESCRIPTION
This is necessary so that /persist is mounted and
.macaddr can be read by the wifi code.
Also, add a service to persist the mac address if the
/persist/wifi/.macaddr didn't exist yet, so that this
address stays the same across reboots.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>