### PR TITLE
hammerhead, mako, tenderloin: Use Halium image built with Ports repos

### DIFF
--- a/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin.bb
+++ b/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin.bb
@@ -2,7 +2,7 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "tenderloin"
 
-PV = "20170914-5"
+PV = "20170918-2"
 
 # Fixing QA errors for not matching architecture for the following binaries:
 # - /system/etc/firmware/q6.mdt
@@ -23,5 +23,5 @@ INSANE_SKIP_${PN} += "textrel"
 INSANE_SKIP_${PN} += "already-stripped"
 
 SRC_URI = "http://build.webos-ports.org/halium-wop-12.1/halium-wop-12.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "7060dc1ec09726f3c92691c6fa5f4a97"
-SRC_URI[sha256sum] = "ccf066ffb0d318b8b88a407325756ab2c1b01d048adfb275c8ba4f906b667618"
+SRC_URI[md5sum] = "536f9f4e8062ddca65efbb2cf9ed42d9"
+SRC_URI[sha256sum] = "be29a3a20ce80d659159564ea6df4d78d9c0f72686bc8b88afd8cc484b56137d"

--- a/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead.bb
@@ -2,7 +2,7 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "hammerhead"
 
-PV = "20170914-5"
+PV = "20170918-2"
 
 # Fixing QA errors for not matching architecture for the following binaries:
 # - /system/etc/firmware/vidc.b00
@@ -17,8 +17,8 @@ INSANE_SKIP_${PN} += "textrel"
 INSANE_SKIP_${PN} += "already-stripped"
 
 SRC_URI = "http://build.webos-ports.org/halium-wop-12.1/halium-wop-12.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "ac2dc0e9a8ebc5763e578863ee16f675"
-SRC_URI[sha256sum] = "85f7df083b1ecf093b0e9d406fcf7e2e528c2107991fbe99e2bc95cc80f0380b"
+SRC_URI[md5sum] = "0b276d5f93bb12e52bf6839627c11882"
+SRC_URI[sha256sum] = "4357acbdf34ea86a8ae4b270972d4c02ff3327271c9fb679c6ddecfd46a6d96d"
 
 do_install_prepend() {
     # fixup libGLESv3.so if needed

--- a/meta-lg/recipes-core/android-system-image/android-system-image-mako.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-mako.bb
@@ -2,7 +2,7 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "mako"
 
-PV = "20170914-5"
+PV = "20170918-2"
 
 # Fixing QA errors for not matching architecture for the following binaries:
 # - /system/etc/firmware/vidc.b00
@@ -17,8 +17,8 @@ INSANE_SKIP_${PN} += "textrel"
 INSANE_SKIP_${PN} += "already-stripped"
 
 SRC_URI = "http://build.webos-ports.org/halium-wop-12.1/halium-wop-12.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "ec13a6cf60f194aead1f89f95a822991"
-SRC_URI[sha256sum] = "6ed2df4f8dfb3616ab595f6b020ff4981c470d4ef989f6d9328647dac673ce49"
+SRC_URI[md5sum] = "170df4a46fe9526cb26093983d2bb2c1"
+SRC_URI[sha256sum] = "cb7767ddabcf50f8fc894e1a7538c557de44ee8984cd4bd763688dd90312b010"
 
 do_install_prepend() {
     # fixup libGLESv3.so if needed


### PR DESCRIPTION
instead of Tofee repos.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>