### PR TITLE
android-system-image-mako: fix typo

### DIFF
--- a/meta-lg/recipes-core/android-system-image/android-system-image-mako.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-mako.bb
@@ -28,6 +28,6 @@ do_install_prepend() {
     fi
     # fixup executable flag for binaries in /system/bin
     for i in ${WORKDIR}/system/bin/* ; do
-       [[ -f $î ]] && chmod +x $i
+       [[ -f $i ]] && chmod +x $i
     done
 }


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>