### PR TITLE
android-system-image: Add symbolic link for wifi

### DIFF
--- a/meta-android/recipes-core/android-system-image/android-system-image.inc
+++ b/meta-android/recipes-core/android-system-image/android-system-image.inc
@@ -30,6 +30,7 @@ do_install() {
     done
 
     install -d ${D}${sysconfdir}
+    ln -sf /system/etc/wifi ${D}${sysconfdir}/wifi
     ln -sf /system/etc/media_codecs.xml ${D}${sysconfdir}/media_codecs.xml
     ln -sf /system/etc/media_profiles ${D}${sysconfdir}/media_profiles.xml
 


### PR DESCRIPTION
Required for using the Halium kernel, since they expect it in this
location with their defconfig, otherwise scanning wifi networks doesn't
work:

Sep 29 06:25:49 hammerhead kernel[896]: [  297.500642] =========== WLAN
going back to live  ========
Sep 29 06:25:49 hammerhead kernel[896]: [
297.661836] _dhdsdio_download_firmware: dongle nvram file download
failed
Sep 29 06:25:49 hammerhead kernel[896]: [  297.661977]
dhd_bus_start: dhdsdio_probe_download failed. firmware =
/vendor/firmware/fw_bcmdhd.bin nvram = /etc/wifi/bcmdhd.cal
Sep 29
06:25:49 hammerhead kernel[896]: [  297.662083] dhd_bus_devreset:
dhd_bus_start fail with -1
Sep 29 06:25:49 hammerhead kernel[896]: [
297.662142] dhd_dev_reset: dhd_bus_devreset: -1
Sep 29 06:25:49
hammerhead kernel[896]: [  297.662294] dhd_open : wl_android_wifi_on
failed (-1)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>