### PR TITLE
mako: Fix the kernel build

### DIFF
--- a/meta-lg/recipes-kernel/linux/linux-lg-mako/0001-Force-WLAN-to-be-build-as-module.patch
+++ b/meta-lg/recipes-kernel/linux/linux-lg-mako/0001-Force-WLAN-to-be-build-as-module.patch
@@ -1,0 +1,27 @@
+From 6caddc58ec6096d31a45649a70d6af98268cd1f0 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Wed, 18 Oct 2017 13:41:33 +0200
+Subject: [PATCH] Force WLAN to be build as module
+
+Since we need this for fixed MAC address currently on Mako.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ arch/arm/configs/mako_defconfig | 2 +-
+ 1 file changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/arch/arm/configs/mako_defconfig b/arch/arm/configs/mako_defconfig
+index 4784a9c..db1bf47 100644
+--- a/arch/arm/configs/mako_defconfig
++++ b/arch/arm/configs/mako_defconfig
+@@ -2016,7 +2016,7 @@ CONFIG_PREEMPT_RCU=y
+ # CONFIG_PREEMPT_TRACER is not set
+ # CONFIG_PREEMPT_VOLUNTARY is not set
+ CONFIG_PREVENT_FIRMWARE_BUILD=y
+-CONFIG_PRIMA_WLAN=y
++CONFIG_PRIMA_WLAN=m
+ # CONFIG_PRIMA_WLAN_11AC_HIGH_TP is not set
+ # CONFIG_PRIMA_WLAN_BTAMP is not set
+ CONFIG_PRIMA_WLAN_LFR=y
+-- 
+2.13.2.windows.1

--- a/meta-lg/recipes-kernel/linux/linux-lg-mako_git.bb
+++ b/meta-lg/recipes-kernel/linux/linux-lg-mako_git.bb
@@ -18,6 +18,7 @@ inherit kernel_android
 
 SRC_URI = " \
   git://github.com/ubports/android_kernel_google_msm.git;branch=ubp-5.1 \
+  file://0001-Force-WLAN-to-be-build-as-module.patch \  
 "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Make sure we build the wlan as module in our defconfig.
Required for static MAC on our targets currently.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>