### PR TITLE
android-system-image: Update halium bits to halium version numbers

### DIFF
--- a/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin.bb
+++ b/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin.bb
@@ -2,7 +2,7 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "tenderloin"
 
-PV = "20170923-3"
+PV = "20171130-5"
 
 # Fixing QA errors for not matching architecture for the following binaries:
 # - /system/etc/firmware/q6.mdt
@@ -22,6 +22,6 @@ INSANE_SKIP_${PN} += "textrel"
 # Skip already-stripped check, because it's prebuilt outside OE so we cannot easily prevent stripping it here
 INSANE_SKIP_${PN} += "already-stripped"
 
-SRC_URI = "http://build.webos-ports.org/halium-wop-12.1/halium-wop-12.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "966e3fcd2414310791fc35a91b4f4bb8"
-SRC_URI[sha256sum] = "98672c975cebdc593f94f3cd3d46c26f4b40dbcce16f72e2c38516db12d292a8"
+SRC_URI = "http://build.webos-ports.org/halium-wop-5.1/halium-wop-5.1-${PV}-${MACHINE}.tar.bz2"
+SRC_URI[md5sum] = "35683ec36e97fa593271091e5745bee4"
+SRC_URI[sha256sum] = "02efd7c8d182b6d44e9936a4b3277d3b7e2cb7396becec8e61f0ed76ad463a1b"

--- a/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead.bb
@@ -2,7 +2,7 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "hammerhead"
 
-PV = "20170918-2"
+PV = "20171130-5"
 
 # Fixing QA errors for not matching architecture for the following binaries:
 # - /system/etc/firmware/vidc.b00
@@ -16,9 +16,9 @@ INSANE_SKIP_${PN} += "textrel"
 # Skip already-stripped check, because it's prebuilt outside OE so we cannot easily prevent stripping it here
 INSANE_SKIP_${PN} += "already-stripped"
 
-SRC_URI = "http://build.webos-ports.org/halium-wop-12.1/halium-wop-12.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "0b276d5f93bb12e52bf6839627c11882"
-SRC_URI[sha256sum] = "4357acbdf34ea86a8ae4b270972d4c02ff3327271c9fb679c6ddecfd46a6d96d"
+SRC_URI = "http://build.webos-ports.org/halium-wop-5.1/halium-wop-5.1-${PV}-${MACHINE}.tar.bz2"
+SRC_URI[md5sum] = "155471e00dc12e61745274898103fbd1"
+SRC_URI[sha256sum] = "64c6d4c48678d22a6d24ecf8be2e3bdd1867d15ea27c7db03dccbe2d6866cb4f"
 
 do_install_prepend() {
     # fixup libGLESv3.so if needed

--- a/meta-lg/recipes-core/android-system-image/android-system-image-mako.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-mako.bb
@@ -2,7 +2,7 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "mako"
 
-PV = "20170918-2"
+PV = "20171130-5"
 
 # Fixing QA errors for not matching architecture for the following binaries:
 # - /system/etc/firmware/vidc.b00
@@ -16,9 +16,9 @@ INSANE_SKIP_${PN} += "textrel"
 # Skip already-stripped check, because it's prebuilt outside OE so we cannot easily prevent stripping it here
 INSANE_SKIP_${PN} += "already-stripped"
 
-SRC_URI = "http://build.webos-ports.org/halium-wop-12.1/halium-wop-12.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "170df4a46fe9526cb26093983d2bb2c1"
-SRC_URI[sha256sum] = "cb7767ddabcf50f8fc894e1a7538c557de44ee8984cd4bd763688dd90312b010"
+SRC_URI = "http://build.webos-ports.org/halium-wop-5.1/halium-wop-5.1-${PV}-${MACHINE}.tar.bz2"
+SRC_URI[md5sum] = "a19ade34eb59d210cd0283c692aa4043"
+SRC_URI[sha256sum] = "0bdec9a54e8b101dda3ed6a30bd1c55aef35cbae6af462446978ca006b63187b"
 
 do_install_prepend() {
     # fixup libGLESv3.so if needed


### PR DESCRIPTION
Use Android/Halium version numbers instead of CM/LineageOS version numbering.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>