### PR TITLE
android-headers-halium: set preferred version

### DIFF
--- a/meta-hp/conf/machine/tenderloin.conf
+++ b/meta-hp/conf/machine/tenderloin.conf
@@ -25,6 +25,7 @@ PREFERRED_PROVIDER_virtual/libgles1 ?= "libhybris"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "libhybris"
 
 PREFERRED_PROVIDER_virtual/android-headers = "android-headers-halium"
+PREFERRED_VERSION_android-headers-halium = "5.1+git%"
 VIRTUAL-RUNTIME_android-system-image = "android-system-image-tenderloin"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"

--- a/meta-lg/conf/machine/hammerhead.conf
+++ b/meta-lg/conf/machine/hammerhead.conf
@@ -20,6 +20,7 @@ PREFERRED_PROVIDER_virtual/libgles1 ?= "libhybris"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "libhybris"
 
 PREFERRED_PROVIDER_virtual/android-headers = "android-headers-halium"
+PREFERRED_VERSION_android-headers-halium = "5.1+git%"
 VIRTUAL-RUNTIME_android-system-image = "android-system-image-hammerhead"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"

--- a/meta-lg/conf/machine/mako.conf
+++ b/meta-lg/conf/machine/mako.conf
@@ -20,6 +20,7 @@ PREFERRED_PROVIDER_virtual/libgles1 ?= "libhybris"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "libhybris"
 
 PREFERRED_PROVIDER_virtual/android-headers = "android-headers-halium"
+PREFERRED_VERSION_android-headers-halium = "5.1+git%"
 VIRTUAL-RUNTIME_android-system-image = "android-system-image-mako"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"

--- a/meta-motorola/conf/machine/athene.conf
+++ b/meta-motorola/conf/machine/athene.conf
@@ -20,6 +20,7 @@ PREFERRED_PROVIDER_virtual/libgles1 ?= "libhybris"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "libhybris"
 
 PREFERRED_PROVIDER_virtual/android-headers = "android-headers-halium"
+PREFERRED_VERSION_android-headers-halium = "7.1+git%"
 VIRTUAL-RUNTIME_android-system-image = "android-system-image-athene"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"

--- a/meta-oneplus/conf/machine/onyx.conf
+++ b/meta-oneplus/conf/machine/onyx.conf
@@ -22,6 +22,7 @@ PREFERRED_PROVIDER_virtual/libgles1 ?= "libhybris"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "libhybris"
 
 PREFERRED_PROVIDER_virtual/android-headers = "android-headers-halium"
+PREFERRED_VERSION_android-headers-halium = "7.1+git%"
 VIRTUAL-RUNTIME_android-system-image = "android-system-image-onyx"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"

--- a/meta-xiaomi/conf/machine/mido.conf
+++ b/meta-xiaomi/conf/machine/mido.conf
@@ -20,6 +20,7 @@ PREFERRED_PROVIDER_virtual/libgles1 ?= "libhybris"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "libhybris"
 
 PREFERRED_PROVIDER_virtual/android-headers = "android-headers-halium"
+PREFERRED_VERSION_android-headers-halium = "7.1+git%"
 VIRTUAL-RUNTIME_android-system-image = "android-system-image-mido"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"


### PR DESCRIPTION
We now have two providers, one for 5.1 and one for 7.1.
If we don't specify which version is wanted, bitbake will
choose for us, which can lead to using the wrong version.