### PR TITLE
android-headers: make it possible to tweak android-config.h per machine

### DIFF
--- a/meta-android/recipes-android/android-headers/android-headers.inc
+++ b/meta-android/recipes-android/android-headers/android-headers.inc
@@ -11,9 +11,15 @@ do_install() {
     install -d ${D}${includedir}/android
     cp -rv ${S}/git/* ${D}${includedir}/android/
 
-    if [ -e ${S}/android-config_${MACHINE}.h ] ; then
+    if [ -n "${ANDROID_HEADERS_DEFINES}" ] ; then
         rm ${D}${includedir}/android/android-config.h
-        install ${S}/android-config_${MACHINE}.h ${D}${includedir}/android-config.h
+        sed '/\/\* CONFIG GOES HERE/,$d' ${S}/git/android-config.h > android-config.h.pre
+        sed '0,/\/\* CONFIG GOES HERE/d' ${S}/git/android-config.h > android-config.h.post
+        for i in ${ANDROID_HEADERS_DEFINES}; do
+          echo "#define $i 1" >> android-config_${MACHINE}.h
+        done
+        cat android-config.h.pre android-config_${MACHINE}.h android-config.h.post >> android-config.h.new
+        install android-config.h.new ${D}${includedir}/android/android-config.h
     fi
 
     install -d ${D}${libdir}/pkgconfig

--- a/meta-hp/conf/machine/tenderloin.conf
+++ b/meta-hp/conf/machine/tenderloin.conf
@@ -27,6 +27,7 @@ PREFERRED_PROVIDER_virtual/libgles2 ?= "libhybris"
 PREFERRED_PROVIDER_virtual/android-headers = "android-headers-halium"
 PREFERRED_VERSION_android-headers-halium = "5.1+git%"
 VIRTUAL-RUNTIME_android-system-image = "android-system-image-tenderloin"
+ANDROID_HEADERS_DEFINES = "QCOM_BSP QCOM_DIRECTTRACK"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 XSERVER = " \

--- a/meta-hp/recipes-core/libhybris/libhybris_%.bbappend
+++ b/meta-hp/recipes-core/libhybris/libhybris_%.bbappend
@@ -1,5 +1,2 @@
 # we have android-headers-tenderloin
 COMPATIBLE_MACHINE_tenderloin = "(^tenderloin$)"
-
-CFLAGS_append_tenderloin = " -DQCOM_DIRECTTRACK -DQCOM_BSP"
-CXXFLAGS_append_tenderloin = " -DQCOM_DIRECTTRACK -DQCOM_BSP"


### PR DESCRIPTION
Note that all the recipes that currently depend on android-headers (except libhybris) are themselves only pointed as RDEPENDS from our packaging recipe. So this doesn't result in a cascade of MACHINE_ARCH recipes.

We still have to keep libhybris in SIGGEN_EXCLUDERECIPES_ABISAFE, for the same reason as before.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>