### PR TITLE
PATCH] athene, mido, onyx: Fix display size and add ANDROID_HEADERS_D…

### DIFF
--- a/meta-motorola/conf/machine/athene.conf
+++ b/meta-motorola/conf/machine/athene.conf
@@ -10,8 +10,8 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-motorola-athene"
 MACHINE_KERNEL_PR = "r0"
 
 MACHINE_FEATURES = "apm alsa bluetooth gps usbgadget usbhost phone wifi vfat ext2 keyboard nfc"
-MACHINE_DISPLAY_WIDTH_PIXELS = "1920"
-MACHINE_DISPLAY_HEIGHT_PIXELS = "1080"
+MACHINE_DISPLAY_WIDTH_PIXELS = "1080"
+MACHINE_DISPLAY_HEIGHT_PIXELS = "1920"
 MACHINE_DISPLAY_ORIENTATION = "0"
 MACHINE_DISPLAY_PPI = "401"
 
@@ -22,6 +22,7 @@ PREFERRED_PROVIDER_virtual/libgles2 ?= "libhybris"
 PREFERRED_PROVIDER_virtual/android-headers = "android-headers-halium"
 PREFERRED_VERSION_android-headers-halium = "7.1+git%"
 VIRTUAL-RUNTIME_android-system-image = "android-system-image-athene"
+ANDROID_HEADERS_DEFINES = "QCOM_BSP QTI_BSP QCOM_HARDWARE"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 XSERVER = " \

--- a/meta-oneplus/conf/machine/onyx.conf
+++ b/meta-oneplus/conf/machine/onyx.conf
@@ -12,8 +12,8 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-oneplus-onyx"
 MACHINE_KERNEL_PR = "r0"
 
 MACHINE_FEATURES = "apm alsa bluetooth gps usbgadget usbhost phone wifi vfat ext2 keyboard nfc"
-MACHINE_DISPLAY_WIDTH_PIXELS = "1920"
-MACHINE_DISPLAY_HEIGHT_PIXELS = "1080"
+MACHINE_DISPLAY_WIDTH_PIXELS = "1080"
+MACHINE_DISPLAY_HEIGHT_PIXELS = "1920"
 MACHINE_DISPLAY_ORIENTATION = "0"
 MACHINE_DISPLAY_PPI = "441"
 
@@ -24,6 +24,7 @@ PREFERRED_PROVIDER_virtual/libgles2 ?= "libhybris"
 PREFERRED_PROVIDER_virtual/android-headers = "android-headers-halium"
 PREFERRED_VERSION_android-headers-halium = "7.1+git%"
 VIRTUAL-RUNTIME_android-system-image = "android-system-image-onyx"
+ANDROID_HEADERS_DEFINES = "QCOM_BSP QTI_BSP QCOM_HARDWARE"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 XSERVER = " \

--- a/meta-xiaomi/conf/machine/mido.conf
+++ b/meta-xiaomi/conf/machine/mido.conf
@@ -10,8 +10,8 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-xiaomi-mido"
 MACHINE_KERNEL_PR = "r0"
 
 MACHINE_FEATURES = "apm alsa bluetooth gps usbgadget usbhost phone wifi vfat ext2 keyboard nfc"
-MACHINE_DISPLAY_WIDTH_PIXELS = "1920"
-MACHINE_DISPLAY_HEIGHT_PIXELS = "1080"
+MACHINE_DISPLAY_WIDTH_PIXELS = "1080"
+MACHINE_DISPLAY_HEIGHT_PIXELS = "1920"
 MACHINE_DISPLAY_ORIENTATION = "0"
 MACHINE_DISPLAY_PPI = "403"
 
@@ -22,6 +22,7 @@ PREFERRED_PROVIDER_virtual/libgles2 ?= "libhybris"
 PREFERRED_PROVIDER_virtual/android-headers = "android-headers-halium"
 PREFERRED_VERSION_android-headers-halium = "7.1+git%"
 VIRTUAL-RUNTIME_android-system-image = "android-system-image-mido"
+ANDROID_HEADERS_DEFINES = "QCOM_BSP QTI_BSP QCOM_HARDWARE"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 XSERVER = " \


### PR DESCRIPTION
…EFINES

Display size was wrong, values were switched. Added ANDROID_HEADERS_DEFINES that were introduced as per https://github.com/shr-distribution/meta-smartphone/pull/58/files

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>