### PR TITLE
android-system: Add missing groups

### DIFF
--- a/meta-android/recipes-core/android-system/android-system_1.0.bb
+++ b/meta-android/recipes-core/android-system/android-system_1.0.bb
@@ -32,7 +32,75 @@ SRC_URI = " \
 
 # Create additional android users we need (need to have same UIDs as in android)
 USERADD_PACKAGES = "${PN}"
-USERADD_PARAM_${PN} = "-u 1000 -M system; -u 1001 -M radio"
+USERADD_PARAM_${PN} = " \
+                       -u 1000 -M system; \
+                       -u 1001 -M radio; \
+                       -u 1002 -M bluetooth; \
+                       -u 1003 -M graphics; \
+                       -u 1006 -M camera; \
+                       -u 1007 -M log; \
+                       -u 1008 -M compass; \
+                       -u 1010 -M wifi; \
+                       -u 1011 -M adb; \
+                       -u 1012 -M install; \
+                       -u 1013 -M media; \
+                       -u 1014 -M dhcp; \
+                       -u 1015 -M sdcard_rw; \
+                       -u 1016 -M vpn; \
+                       -u 1017 -M keystore; \
+                       -u 1018 -M usb; \
+                       -u 1019 -M drm; \
+                       -u 1020 -M mdnsr; \
+                       -u 1021 -M gps; \
+                       -u 1023 -M media_rw; \
+                       -u 1024 -M mtp; \
+                       -u 1026 -M drmrpc; \
+                       -u 1027 -M nfc; \
+                       -u 1028 -M sdcard_r; \
+                       -u 1029 -M clat; \
+                       -u 1030 -M loop_radio; \
+                       -u 1031 -M mediadrm; \
+                       -u 1032 -M package_info; \
+                       -u 1033 -M sdcard_pics; \
+                       -u 1034 -M sdcard_av; \
+                       -u 1035 -M sdcard_all; \
+                       -u 1036 -M logd; \
+                       -u 1037 -M shared_relro; \
+                       -u 1038 -M dbus; \
+                       -u 1039 -M tlsdate; \
+                       -u 1040 -M mediaex; \
+                       -u 1041 -M audioserver; \
+                       -u 1042 -M metrics_coll; \
+                       -u 1043 -M metricsd; \
+                       -u 1044 -M webserv; \
+                       -u 1045 -M debuggerd; \
+                       -u 1046 -M mediacodec; \
+                       -u 1047 -M cameraserver; \
+                       -u 1048 -M firewall; \
+                       -u 1049 -M trunks; \
+                       -u 1050 -M nvram; \
+                       -u 1051 -M dns; \
+                       -u 1052 -M dns_tether; \
+                       -u 2000 -M shell; \
+                       -u 2001 -M cache; \
+                       -u 2002 -M diag; \
+                       -u 2950 -M qcom_diag; \
+                       -u 2951 -M rfs; \
+                       -u 2952 -M rfs_shared; \
+                       -u 3001 -M net_bt_admin; \
+                       -u 3002 -M net_bt; \
+                       -u 3003 -M inet; \
+                       -u 3004 -M net_raw; \
+                       -u 3005 -M net_admin; \
+                       -u 3006 -M net_bw_stats; \
+                       -u 3007 -M net_bw_acct; \
+                       -u 3008 -M net_bt_stack; \
+                       -u 3009 -M readproc; \
+                       -u 3010 -M wakelock; \
+                       -u 3011 -M sensors; \
+                       -u 9997 -M everybody; \
+                       -u 9998 -M misc; \
+                       -u 9999 -M nobody; "
 
 do_install() {
     install -d ${D}${systemd_unitdir}/system


### PR DESCRIPTION
Android added quite some groups and functionality over time, however we never added these to our build and this would potentially cause issues with various hardware components, especially on 7.1 based builds. Seeing both Mer and UB Ports are using the majority of these already, I added the missing groups from 7.1 android_filesystem_config.h so we're complete.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>