### PR TITLE
meta-xiaomi: Mido enable WLAN as module

### DIFF
--- a/meta-xiaomi/conf/machine/mido.conf
+++ b/meta-xiaomi/conf/machine/mido.conf
@@ -36,6 +36,7 @@ XSERVER = " \
 MACHINE_EXTRA_RDEPENDS = " \
     android-kernel-bootimg \
     dosfstools \
+    kernel-module-wlan \
 "
 
 KERNEL_IMAGETYPE = "Image.gz-dtb"

--- a/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-mido_git.bb
+++ b/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-mido_git.bb
@@ -9,7 +9,7 @@ DESCRIPTION = "Linux kernel for the Xiaomi Mido (Redmi Note 4, Snapdragon) devic
 source from Xiaomi"
 
 SRC_URI = " \
-  git://github.com/piggz/android_kernel_xiaomi_msm8953.git;branch=pgz-14.1-eb8 \
+  git://github.com/herrie82/android_kernel_xiaomi_msm8953.git;branch=pgz-14.1-eb8 \
 "
 S = "${WORKDIR}/git"
 
@@ -19,7 +19,7 @@ do_configure_prepend() {
     cp -v -f ${S}/arch/arm64/configs/mido_defconfig ${WORKDIR}/defconfig
 }
 
-SRCREV = "8b078d06e88d34e79222237cf74b99c2d97db98d"
+SRCREV = "f974d591e9553d614fe4cc56b190f9aa598c8197"
 
 KV = "3.18.85"
 PV = "${KV}+gitr${SRCPV}"


### PR DESCRIPTION
We need WLAN to be build as module.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>