### PR TITLE
meta-xiaomi: mido use correct wlan module name

### DIFF
--- a/meta-xiaomi/recipes-core/systemd/systemd-machine-units/mido/wifi-module-load.service
+++ b/meta-xiaomi/recipes-core/systemd/systemd-machine-units/mido/wifi-module-load.service
@@ -6,11 +6,11 @@ Conflicts=shutdown.target actdead.target
 [Service]
 Type=simple
 RemainAfterExit=yes
-ExecStart=/sbin/modprobe bcmdhd
-ExecStop=/sbin/rmmod bcmdhd
+ExecStartPre=/bin/touch /dev/wcnss_wlan
+ExecStart=/sbin/modprobe wlan
+ExecStop=/sbin/modprobe -r wlan
 Restart=on-failure
 RestartSec=2
 
 [Install]
 WantedBy=basic.target
-


### PR DESCRIPTION
After Halium 7.1 finally included the necessary network bits (iptables, iproute2 etc) seems that WiFi module will now load correctly.

Therefore update the script to reflect the correct module name. Taken from https://github.com/piggz/droid-config-mido/blob/master/sparse/lib/systemd/system/wlan-module-load.service

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>