### PR TITLE
meta-xiaomi: Get image for Tissot building

### DIFF
--- a/meta-xiaomi/conf/machine/tissot.conf
+++ b/meta-xiaomi/conf/machine/tissot.conf
@@ -36,7 +36,7 @@ XSERVER = " \
 MACHINE_EXTRA_RDEPENDS = " \
     android-kernel-bootimg \
     dosfstools \
-    kernel-module-wlan \
+    kernel-module-wil6210 \
 "
 
 KERNEL_IMAGETYPE = "Image.gz-dtb"

--- a/meta-xiaomi/recipes-core/android-system-image/android-system-image-tissot.bb
+++ b/meta-xiaomi/recipes-core/android-system-image/android-system-image-tissot.bb
@@ -2,8 +2,8 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "tissot"
 
-PV = "20180311-10"
+PV = "20180628-1"
 
 SRC_URI = "http://build.webos-ports.org/halium-luneos-7.1/halium-luneos-7.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "878b45c77827a72cf34423b2e876f55e"
-SRC_URI[sha256sum] = "0bc719a093781870e91d799ef4d5670d6fc80f37074c0b9c0a2d88921fd47799"
+SRC_URI[md5sum] = "998ed9bfbf2e4d5eff0ce0f00725db27"
+SRC_URI[sha256sum] = "bcf6d729c1d706780e790d26765a6932f93bbf1309939fba80b0e211650c7cae"

--- a/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-tissot_git.bb
+++ b/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-tissot_git.bb
@@ -21,7 +21,7 @@ do_configure_prepend() {
     cp -v -f ${S}/arch/arm64/configs/tissot-perf_defconfig ${WORKDIR}/defconfig
 }
 
-SRCREV = "fd3294d250974b9a6fe82a31660ee72789517c26"
+SRCREV = "e9c763e01ee734b37f250af1b7c4155ccd6bae19"
 
 KV = "3.18.113"
 PV = "${KV}+gitr${SRCPV}"


### PR DESCRIPTION
These fixes are required to get the image for Tissot building successfully.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>