### PR TITLE
android-system-image-tissot: Bump PV to fix adb

### DIFF
--- a/meta-xiaomi/recipes-core/android-system-image/android-system-image-tissot.bb
+++ b/meta-xiaomi/recipes-core/android-system-image/android-system-image-tissot.bb
@@ -2,8 +2,8 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "tissot"
 
-PV = "20180802-18"
+PV = "20180807-19"
 
 SRC_URI = "http://build.webos-ports.org/halium-luneos-7.1/halium-luneos-7.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "2840c9ef9aa94afbbb97878afdd3a9d3"
-SRC_URI[sha256sum] = "59816d52dfe4b83ecb5e652a260a232f0aae26767510c90885d43a812ce6b90d"
+SRC_URI[md5sum] = "fd6bde30bcaad219a1951179e9c6216e"
+SRC_URI[sha256sum] = "a33ff250bcfc09f75f62b5e4c6cf8e7681defb040f2d61e763bc6d0efe1416f0"


### PR DESCRIPTION
New defconfig was to be used, so bumping the Android image as well.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>