### PR TITLE
android-system-image-tissot: Bump PV to kill qseeproxydaemon on Andro…

### DIFF
--- a/meta-xiaomi/recipes-core/android-system-image/android-system-image-tissot.bb
+++ b/meta-xiaomi/recipes-core/android-system-image/android-system-image-tissot.bb
@@ -2,8 +2,8 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "tissot"
 
-PV = "20180807-19"
+PV = "20180809-20"
 
 SRC_URI = "http://build.webos-ports.org/halium-luneos-7.1/halium-luneos-7.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "fd6bde30bcaad219a1951179e9c6216e"
-SRC_URI[sha256sum] = "a33ff250bcfc09f75f62b5e4c6cf8e7681defb040f2d61e763bc6d0efe1416f0"
+SRC_URI[md5sum] = "918bb234cfeffd86e6a99cacb6d43eca"
+SRC_URI[sha256sum] = "610fc86db3fc9914f2242ab4b1c831652356db5d0e0d386affceb7c756f7f331"


### PR DESCRIPTION
…id side

We don't need qseeproxydaemon so killed it in Android's init.rc.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>