### PR TITLE
android-kernel-bootimg: minimal support for A/B partitions

### DIFF
--- a/meta-android/recipes-android/android-kernel-bootimg/android-kernel-bootimg.bb
+++ b/meta-android/recipes-android/android-kernel-bootimg/android-kernel-bootimg.bb
@@ -61,7 +61,7 @@ pkg_postinst_${PN}_append () {
             exit 1
         fi
 
-        BOOT_PARTITION_NAMES="LNX boot KERNEL"
+        BOOT_PARTITION_NAMES="LNX boot boot_a KERNEL"
         for i in $BOOT_PARTITION_NAMES; do
             path=$(find /dev -name "$i"|grep disk| head -n 1)
             [ -n "$path" ] && break


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>