### PR TITLE
libhybris: Bump SRCREV

### DIFF
--- a/meta-android/recipes-core/libhybris/libhybris_git.bb
+++ b/meta-android/recipes-core/libhybris/libhybris_git.bb
@@ -3,7 +3,7 @@ bionic-based HW adaptations in glibc systems"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRCREV = "4aa3379de1d911f00a86cb5643f7ff63dd48d7a6"
+SRCREV = "3beca8ad9246e3fce3c47ef978c3b07f6c04284a"
 PV = "0.1.0+gitr${SRCPV}"
 PR = "r1"
 PE = "1"


### PR DESCRIPTION
To latest upstream commit.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>