### PR TITLE
android-system-image: bump mako,tenderloin,hammerhead

### DIFF
--- a/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin.bb
+++ b/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin.bb
@@ -2,8 +2,8 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "tenderloin"
 
-PV = "20180311-15"
+PV = "20181023-19"
 
 SRC_URI = "http://build.webos-ports.org/halium-luneos-5.1/halium-luneos-5.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "475ad34433d7a6e66db3084c9e1587e9"
-SRC_URI[sha256sum] = "ba67f4e6b38dacd12e62d5dbda75831828d2d6ebf61d2d7695a57e4493a06d9c"
+SRC_URI[md5sum] = "e2de944384df39812406aae297bd8bcb"
+SRC_URI[sha256sum] = "2f2211fb59d412df249d91e61a45358fe4a5c9e6684155cb817450ca90da38c6"

--- a/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead.bb
@@ -2,8 +2,8 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "hammerhead"
 
-PV = "20180311-15"
+PV = "20181023-19"
 
 SRC_URI = "http://build.webos-ports.org/halium-luneos-5.1/halium-luneos-5.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "250c611827c4c63d35d173f001b371ff"
-SRC_URI[sha256sum] = "df77358b9361f736beebcbb15c53353480a565bdaa90cdb3a1052b913c12fe45"
+SRC_URI[md5sum] = "03e4379ae9e2adca351ab797f7d9bda8"
+SRC_URI[sha256sum] = "36dec20dbbb5f3e9f308c9a5f25e770cd478a8f1057860080a8e2bc3023e45eb"

--- a/meta-lg/recipes-core/android-system-image/android-system-image-mako.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-mako.bb
@@ -2,8 +2,8 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "mako"
 
-PV = "20180311-15"
+PV = "20181023-19"
 
 SRC_URI = "http://build.webos-ports.org/halium-luneos-5.1/halium-luneos-5.1-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "e905f4695c32886745ad32b12663d9ff"
-SRC_URI[sha256sum] = "cb09752f09953f49c4619a71f6873f27af57eec1247e68a046a17c3bf38cdbd5"
+SRC_URI[md5sum] = "f5056f6807e9df8faf5682fb467be30b"
+SRC_URI[sha256sum] = "3f3a6eaa56fdd138192cf30545b7c0cd6e720b4c4f49bd11d095be5713f85bb6"

--- a/meta-xiaomi/recipes-core/systemd/systemd-machine-units/mido/dev-ttyHS99.device
+++ b/meta-xiaomi/recipes-core/systemd/systemd-machine-units/mido/dev-ttyHS99.device
@@ -1,4 +1,0 @@
-[Unit]
-Description=HCI UART device
-Requires=hciattach.service
-Before=hciattach.service

--- a/meta-xiaomi/recipes-core/systemd/systemd-machine-units/mido/hciattach.service
+++ b/meta-xiaomi/recipes-core/systemd/systemd-machine-units/mido/hciattach.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=Run hciattach when HCI UART device becomes available
+Description=Run hciattach when HCI device becomes available
+Requires=bluetooth.service
 Before=bluetooth.service
-After=android-system.service dev-ttyHS99.device
-ConditionPathExists=/system/vendor/firmware
+After=android-system.service 
 
 [Service]
 Type=oneshot
@@ -10,4 +10,4 @@ ExecStart=/usr/bin/hciattach.sh
 RemainAfterExit=yes
 
 [Install]
-WantedBy=bluetooth.service
+WantedBy=bluetooth.service luna-next.service

--- a/meta-xiaomi/recipes-core/systemd/systemd-machine-units/mido/hciattach.sh
+++ b/meta-xiaomi/recipes-core/systemd/systemd-machine-units/mido/hciattach.sh
@@ -1,16 +1,29 @@
 #!/bin/sh
 
-# first, get the bluetooth address if possible
-if [ -e /persist/bluetooth/.bdaddr ] ; then
-	bdaddr=$(hexdump -e  '/1 "%X:"' /persist/bluetooth/.bdaddr)
-else
-	bdaddr=""
-fi
+#Maximum number of attempts to enable hcismd to try to get
+# hci0 to come online.  Writing to sysfs too early seems to
+# not work, so we loop.
+MAXTRIES=15
 
-# call hciattach (and strip the last char of bdaddr)
-/usr/bin/hciattach ttyHS99 bcm43xx 4000000 flow sleep ${bdaddr%?}
+#setprop bluetooth.hciattach true
+setprop ro.qualcomm.bt.hci_transport smd
+setprop qcom.bt.dev_power_class 2
+setprop qcom.bt.le_dev_pwr_class 2
 
-sleep 1
+i=1
+while [ ! $i -gt $MAXTRIES ]  ; do
+	echo 1 > /sys/module/hci_smd/parameters/hcismd_set
+	sleep 1
+    if [ -e /sys/class/bluetooth/hci0 ] ; then
+        # found hci0, so unblock bluetooth and exit successfully
+		/usr/sbin/rfkill unblock bluetooth
+		hciconfig hci0 up
+		/usr/sbin/rfkill block bluetooth
+        exit 0
+    fi
+    i=$((i+1))
+done
 
-# unblock bluetooth
-/usr/sbin/rfkill unblock bluetooth
+# must have gotten through all our retries, fail
+exit 1
+

--- a/meta-xiaomi/recipes-core/systemd/systemd-machine-units_1.0.bbappend
+++ b/meta-xiaomi/recipes-core/systemd/systemd-machine-units_1.0.bbappend
@@ -6,7 +6,6 @@ SRC_URI_append_mido = " \
     file://persist-wifi-mac-addr.sh \
     file://hciattach.service \
     file://hciattach.sh \
-    file://dev-ttyHS99.device \
 "
 SRC_URI_append_rosy = " \
     file://wifi-macaddr-persister.service \
@@ -20,7 +19,6 @@ do_install_append_mido() {
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/wifi-macaddr-persister.service ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/hciattach.service ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/dev-ttyHS99.device ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/wifi-module-load.service ${D}${systemd_unitdir}/system
 
     install -d ${D}${bindir}
@@ -42,7 +40,6 @@ SYSTEMD_SERVICE_${PN}_mido = " \
     wifi-macaddr-persister.service \
     wifi-module-load.service \
     hciattach.service \
-    dev-ttyHS99.device \
 "
 
 SRC_URI_append_tissot = " \


### PR DESCRIPTION
The new version includes a new hook which fixes TLS issues
with Qt 5.11

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>