### PR TITLE
linux-lg-mako: send patches upstream and bump SRCREV

### DIFF
--- a/meta-lg/recipes-kernel/linux/linux-lg-mako_git.bb
+++ b/meta-lg/recipes-kernel/linux/linux-lg-mako_git.bb
@@ -10,8 +10,6 @@ source from Google/LG"
 
 SRC_URI = " \
   git://github.com/ubports/android_kernel_google_msm.git;branch=ubp-5.1 \
-  file://0001-compiler-gcc.h-Add-gcc-recommended-GCC_VERSION-macro.patch \
-  file://0001-compiler-gcc-integrate-the-various-compiler-gcc-345-.patch \
   file://0001-Force-WLAN-to-be-build-as-module.patch \  
 "
 S = "${WORKDIR}/git"
@@ -22,7 +20,7 @@ do_configure_prepend() {
     cp -v -f ${S}/arch/arm/configs/mako_defconfig ${WORKDIR}/defconfig
 }
 
-SRCREV = "5f967233e931cd1d5fb542b3221a37f5520c4f30"
+SRCREV = "c2beb2ae393193c10cdd4446f98127dbf4b06768"
 
 KV = "3.4.0"
 PV = "${KV}+gitr${SRCPV}"


### PR DESCRIPTION
 * Includes fix for GCC 7.x
 * Includes fstat fix for systemd 233+

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>