### PR TITLE
libhybris: bump SRCREV

### DIFF
--- a/meta-android/recipes-core/libhybris/libhybris/0001-Fix-test_sensors-printf.patch
+++ b/meta-android/recipes-core/libhybris/libhybris/0001-Fix-test_sensors-printf.patch
@@ -1,0 +1,49 @@
+From 9f4d5f55bfbe76f57676678215fbedc8bde4c89e Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Mon, 27 Feb 2017 19:17:28 +0000
+Subject: [PATCH] Fix test_sensors printf
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ hybris/tests/test_sensors.c | 19 ++++++++++++++++---
+ 1 file changed, 16 insertions(+), 3 deletions(-)
+
+diff --git a/hybris/tests/test_sensors.c b/hybris/tests/test_sensors.c
+index 33a4e02..baec162 100644
+--- a/hybris/tests/test_sensors.c
++++ b/hybris/tests/test_sensors.c
+@@ -48,17 +48,30 @@ static void process_event(sensors_event_t *data)
+     }
+ }
+ 
++void float_to_char(float f,char * buffer, int maxChars){
++    int beforeDot = (int)f;
++    int afterDot = (int)((f-beforeDot)*1e6); /* rounding is not perfect, but that'll do */
++    snprintf(buffer, maxChars, "%d.%d", beforeDot, afterDot);
++}
++
+ static void print_sensor_info(int i, struct sensor_t const *s)
+ {
++    char numStr[32];
++    
+     printf("=== Sensor %d ==\n", i);
+     printf("Name: %s\n", s->name);
+     printf("Vendor: %s\n", s->vendor);
+     printf("Version: 0x%x\n", s->version);
+     printf("Handle: 0x%x\n", s->handle);
+     printf("Type: %d\n", s->type);
+-    printf("maxRange: %.f\n", s->maxRange);
+-    printf("resolution: %.f\n", s->resolution);
+-    printf("power: %.f mA\n", s->power);
++    // once the hw module is loaded, printf with %f will crash, so use integers
++    float_to_char(s->maxRange, numStr, 30);
++    printf("maxRange: %s\n", numStr);
++    float_to_char(s->resolution, numStr, 30);
++    printf("resolution: %s\n", numStr);
++    float_to_char(s->power, numStr, 30);
++    printf("power: %s mA\n", numStr);
++    
+     printf("minDelay: %d\n", s->minDelay);
+     //printf("fifoReservedEventCount: %d\n", s->fifoReservedEventCount);
+     //printf("fifoMaxEventCount: %d\n", s->fifoMaxEventCount);

--- a/meta-android/recipes-core/libhybris/libhybris/0002-tests-make-test_camera-use-wayland.patch
+++ b/meta-android/recipes-core/libhybris/libhybris/0002-tests-make-test_camera-use-wayland.patch
@@ -1,0 +1,193 @@
+From 7588a8188f390e1dc4a324adf94474ebf2bc7f17 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Mon, 27 Feb 2017 19:17:28 +0000
+Subject: [PATCH] tests: make test_camera use wayland
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+ hybris/tests/Makefile.am   |   4 +-
+ hybris/tests/test_camera.c | 109 ++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 109 insertions(+), 4 deletions(-)
+
+diff --git a/hybris/tests/Makefile.am b/hybris/tests/Makefile.am
+index 242436b..cfba29c 100644
+--- a/hybris/tests/Makefile.am
++++ b/hybris/tests/Makefile.am
+@@ -152,13 +152,13 @@ test_camera_SOURCES = test_camera.c
+ test_camera_CFLAGS = \
+ 	-I$(top_srcdir)/include \
+ 	$(ANDROID_HEADERS_CFLAGS)
+-
+ test_camera_LDADD = \
+ 	$(top_builddir)/common/libhybris-common.la \
+ 	$(top_builddir)/egl/libEGL.la \
+ 	$(top_builddir)/glesv2/libGLESv2.la \
+ 	$(top_builddir)/camera/libcamera.la \
+-	$(top_builddir)/input/libis.la
++	$(top_builddir)/input/libis.la \
++	$(top_builddir)/egl/platforms/common/libwayland-egl.la -lwayland-client
+ 
+ test_media_SOURCES = test_media.c
+ test_media_CFLAGS = \
+diff --git a/hybris/tests/test_camera.c b/hybris/tests/test_camera.c
+index 693a6fb..d52d9f5 100644
+--- a/hybris/tests/test_camera.c
++++ b/hybris/tests/test_camera.c
+@@ -17,6 +17,11 @@
+ 
+ #include "config.h"
+ 
++#include <wayland-client.h>
++#include <wayland-server.h>
++#include <wayland-client-protocol.h>
++#include <wayland-egl.h>
++
+ #include <hybris/camera/camera_compatibility_layer.h>
+ #include <hybris/camera/camera_compatibility_layer_capabilities.h>
+ 
+@@ -246,6 +251,7 @@ static GLuint loadShader(GLenum shaderType, const char* pSource) {
+ 	return shader;
+ }
+ 
++
+ static GLuint create_program(const char* pVertexSource, const char* pFragmentSource) {
+ 	GLuint vertexShader = loadShader(GL_VERTEX_SHADER, pVertexSource);
+ 	if (!vertexShader) {
+@@ -286,6 +292,76 @@ static GLuint create_program(const char* pVertexSource, const char* pFragmentSou
+ 	return program;
+ }
+ 
++
++struct wl_display *wldisplay = NULL;
++struct wl_compositor *wlcompositor = NULL;
++struct wl_surface *wlsurface;
++struct wl_egl_window *wlegl_window;
++struct wl_region *wlregion;
++struct wl_shell *wlshell;
++struct wl_shell_surface *wlshell_surface;
++
++static void
++global_registry_handler(void *data, struct wl_registry *registry, uint32_t id,
++	       const char *interface, uint32_t version)
++{
++    printf("Got a registry event for %s id %d\n", interface, id);
++    if (strcmp(interface, "wl_compositor") == 0) {
++        wlcompositor = wl_registry_bind(registry, 
++				      id, 
++				      &wl_compositor_interface, 
++				      1);
++    } else if (strcmp(interface, "wl_shell") == 0) {
++	wlshell = wl_registry_bind(registry, id,
++				 &wl_shell_interface, 1);
++	
++    }
++}
++
++static void
++global_registry_remover(void *data, struct wl_registry *registry, uint32_t id)
++{
++    printf("Got a registry losing event for %d\n", id);
++}
++
++static const struct wl_registry_listener registry_listener = {
++    global_registry_handler,
++    global_registry_remover
++};
++
++static void
++get_server_references(void) {
++
++    wldisplay = wl_display_connect(NULL);
++    if (wldisplay == NULL) {
++	fprintf(stderr, "Can't connect to display\n");
++	exit(1);
++    }
++    printf("connected to display\n");
++
++    struct wl_registry *registry = wl_display_get_registry(wldisplay);
++    wl_registry_add_listener(registry, &registry_listener, NULL);
++
++    wl_display_dispatch(wldisplay);
++    wl_display_roundtrip(wldisplay);
++
++    if (wlcompositor == NULL || wlshell == NULL) {
++	fprintf(stderr, "Can't find compositor or shell\n");
++	exit(1);
++    } else {
++	fprintf(stderr, "Found compositor and shell\n");
++    }
++}
++
++static void
++create_opaque_region() {
++    wlregion = wl_compositor_create_region(wlcompositor);
++    wl_region_add(wlregion, 0, 0,
++		  1024,
++		  1024);
++    wl_surface_set_opaque_region(wlsurface, wlregion);
++}
++
+ int main(int argc, char** argv)
+ {
+ 	struct CameraControlListener listener;
+@@ -356,6 +432,22 @@ int main(int argc, char** argv)
+ 	FocusRegion fr = { top: -200, left: -200, bottom: 200, right: 200, weight: 300};
+ 	android_camera_set_focus_region(cc, &fr);
+ 
++	/* Wayland Setup */
++	get_server_references();
++   
++	wlsurface = wl_compositor_create_surface(wlcompositor);
++	if (wlsurface == NULL) {
++	    fprintf(stderr, "Can't create surface\n");
++	    exit(1);
++	} else {
++	    fprintf(stderr, "Created surface\n");
++	}
++
++	wlshell_surface = wl_shell_get_shell_surface(wlshell, wlsurface);
++	wl_shell_surface_set_toplevel(wlshell_surface);
++	
++	create_opaque_region();
++
+ 	/* EGL Setup */
+ 	EGLConfig ecfg;
+ 	EGLBoolean rv;
+@@ -372,7 +464,7 @@ int main(int argc, char** argv)
+ 		EGL_NONE
+ 	};
+ 
+-	EGLDisplay disp = eglGetDisplay(NULL);
++	EGLDisplay disp = eglGetDisplay((EGLNativeDisplayType)wldisplay);
+ 	assert(eglGetError() == EGL_SUCCESS);
+ 	assert(disp != EGL_NO_DISPLAY);
+ 
+@@ -384,8 +476,16 @@ int main(int argc, char** argv)
+ 	assert(eglGetError() == EGL_SUCCESS);
+ 	assert(rv == EGL_TRUE);
+ 
++	wlegl_window = wl_egl_window_create(wlsurface, 1024, 1024);
++	if (wlegl_window == EGL_NO_SURFACE) {
++	    fprintf(stderr, "Can't create egl window\n");
++	    exit(1);
++	} else {
++	    fprintf(stderr, "Created egl window\n");
++	}
++	
+ 	EGLSurface surface = eglCreateWindowSurface((EGLDisplay) disp, ecfg,
+-			(EGLNativeWindowType) NULL, NULL);
++			(EGLNativeWindowType) wlegl_window, NULL);
+ 	assert(eglGetError() == EGL_SUCCESS);
+ 	assert(surface != EGL_NO_SURFACE);
+ 
+@@ -473,5 +573,10 @@ int main(int argc, char** argv)
+ 		glDisableVertexAttribArray(gaTexHandle);
+ 
+ 		eglSwapBuffers((EGLDisplay) disp, surface);
++		
++		wl_display_dispatch(wldisplay);
+ 	}
++    
++    wl_display_disconnect(wldisplay);
++    
+ }

--- a/meta-android/recipes-core/libhybris/libhybris/0003-hooks.c-Fix-build-with-glibc-2.26.patch
+++ b/meta-android/recipes-core/libhybris/libhybris/0003-hooks.c-Fix-build-with-glibc-2.26.patch
@@ -1,7 +1,7 @@
-From 5ebc16fefe5917f2f29cf46d028866b8e4500df3 Mon Sep 17 00:00:00 2001
+From 1b782b1694b6498ee7e0028e789edca0ff6c8aaa Mon Sep 17 00:00:00 2001
 From: Martin Jansa <Martin.Jansa@gmail.com>
 Date: Fri, 25 Aug 2017 13:06:50 +0200
-Subject: [PATCH] hooks.c: Fix build with glibc-2.26
+Subject: [PATCH 3/3] hooks.c: Fix build with glibc-2.26
 
 * add missing sys/uio.h include for writev
 * replace cfree with free as the cfree man says:
@@ -17,13 +17,12 @@ Subject: [PATCH] hooks.c: Fix build with glibc-2.26
                             ^
 
 Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
-
 ---
  hybris/common/hooks.c | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/hybris/common/hooks.c b/hybris/common/hooks.c
-index 3b21d74..8d08be9 100644
+index 517366e..0e8b916 100644
 --- a/hybris/common/hooks.c
 +++ b/hybris/common/hooks.c
 @@ -65,6 +65,7 @@
@@ -34,12 +33,15 @@ index 3b21d74..8d08be9 100644
  
  #include <sys/mman.h>
  #include <libgen.h>
-@@ -2459,7 +2460,7 @@ static struct _hook hooks_common[] = {
+@@ -2630,7 +2631,7 @@ static struct _hook hooks_common[] = {
      HOOK_INDIRECT(malloc),
-     HOOK_DIRECT_NO_DEBUG(free),
+     HOOK_INDIRECT(free),
      HOOK_DIRECT_NO_DEBUG(calloc),
 -    HOOK_DIRECT_NO_DEBUG(cfree),
 +    HOOK_DIRECT_NO_DEBUG(free),
      HOOK_DIRECT_NO_DEBUG(realloc),
      HOOK_DIRECT_NO_DEBUG(memalign),
      HOOK_DIRECT_NO_DEBUG(valloc),
+-- 
+2.17.1
+

--- a/meta-android/recipes-core/libhybris/libhybris_git.bb
+++ b/meta-android/recipes-core/libhybris/libhybris_git.bb
@@ -9,7 +9,9 @@ PR = "r1"
 PE = "1"
 
 SRC_URI = "git://github.com/libhybris/libhybris \
-    file://0001-hooks.c-Fix-build-with-glibc-2.26.patch;patchdir=.. \
+    file://0001-Fix-test_sensors-printf.patch;patchdir=.. \
+    file://0002-tests-make-test_camera-use-wayland.patch;patchdir=.. \
+    file://0003-hooks.c-Fix-build-with-glibc-2.26.patch;patchdir=.. \
 "
 
 S = "${WORKDIR}/git/hybris"

--- a/meta-android/recipes-core/libhybris/libhybris_git.bb
+++ b/meta-android/recipes-core/libhybris/libhybris_git.bb
@@ -3,7 +3,7 @@ bionic-based HW adaptations in glibc systems"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRCREV = "76f83fcd8a4c5aa43d4342d00af6242a20789a02"
+SRCREV = "f0662b357e69ee74cf3e3e7931a6076a6b7d689c"
 PV = "0.1.0+gitr${SRCPV}"
 PR = "r1"
 PE = "1"


### PR DESCRIPTION
@Tofee this might be useful for anbox in meta-webos-ports, but I'll update this once more when following libhybris PR is merged:
https://github.com/libhybris/libhybris/pull/417

We also need small change in android-property-service:
https://github.com/webOS-ports/android-property-service/pull/3
to make it compatible with new libhybris.