### PR TITLE
udev-extraconf: override automount.rules with empty rules file

### DIFF
--- a/meta-android/recipes-core/udev/udev-extraconf/automount.rules
+++ b/meta-android/recipes-core/udev/udev-extraconf/automount.rules
@@ -1,0 +1,21 @@
+# There are a number of modifiers that are allowed to be used in some
+# of the different fields. They provide the following subsitutions:
+#
+# %n the "kernel number" of the device.
+#    For example, 'sda3' has a "kernel number" of '3'
+# %e the smallest number for that name which does not matches an existing node
+# %k the kernel name for the device
+# %M the kernel major number for the device
+# %m the kernel minor number for the device
+# %b the bus id for the device
+# %c the string returned by the PROGRAM
+# %s{filename} the content of a sysfs attribute
+# %% the '%' char itself
+#
+
+# Media automounting
+## For android-based devices, we don't want to automount all the mmcblk* partitions.
+## So let's override the defaults from openembedded-core.
+# SUBSYSTEM=="block", ACTION=="add"    RUN+="/etc/udev/scripts/mount.sh"
+# SUBSYSTEM=="block", ACTION=="remove" RUN+="/etc/udev/scripts/mount.sh"
+# SUBSYSTEM=="block", ACTION=="change", ENV{DISK_MEDIA_CHANGE}=="1" RUN+="/etc/udev/scripts/mount.sh"


### PR DESCRIPTION
Automount isn't a useful nor a welcome feature on an embedded device.
If the device gets rebooted violently, there are risks of data
corruption on these mounted partitions.
So override automount.rules from openembedded-core, and comment out
all the automount rules.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>