### PR TITLE
kernel: tenderloin, mako, hammerhead, onyx bump SRCREV for GCC8

### DIFF
--- a/meta-hp/recipes-kernel/linux/linux-hp-tenderloin_git.bb
+++ b/meta-hp/recipes-kernel/linux/linux-hp-tenderloin_git.bb
@@ -11,7 +11,7 @@ SRC_URI = " \
 "
 S = "${WORKDIR}/git"
 
-SRCREV = "01141a353241d545a2aaf9addaa32afe39a98562"
+SRCREV = "8371d6ee507ab3fd8ffcb68fdc814b24e71abd13"
 
 do_deploy[depends] += "initramfs-android-image:do_image_complete"
 DEPENDS += "u-boot-mkimage-native"

--- a/meta-lg/recipes-kernel/linux/linux-lg-hammerhead_git.bb
+++ b/meta-lg/recipes-kernel/linux/linux-lg-hammerhead_git.bb
@@ -25,7 +25,7 @@ do_configure_prepend() {
     cp -v -f ${S}/arch/arm/configs/cyanogenmod_hammerhead_defconfig ${WORKDIR}/defconfig
 }
 
-SRCREV = "17a8d0630b424d66981900e701ae2a452d4b8726"
+SRCREV = "2cb0f6675c8363394a3760997d4e05d77077096b"
 
 KV = "3.4.0"
 PV = "${KV}+gitr${SRCPV}"

--- a/meta-lg/recipes-kernel/linux/linux-lg-mako_git.bb
+++ b/meta-lg/recipes-kernel/linux/linux-lg-mako_git.bb
@@ -17,7 +17,7 @@ ANDROID_BOOTIMG_TAGS_RAM_BASE = "0x80200100"
 inherit kernel_android
 
 SRC_URI = " \
-  git://github.com/ubports/android_kernel_google_msm.git;branch=ubp-5.1 \
+  git://github.com/herrie82/android_kernel_google_msm.git;branch=ubp-5.1 \
   file://0001-Force-WLAN-to-be-build-as-module.patch \
 "
 S = "${WORKDIR}/git"
@@ -26,7 +26,7 @@ do_configure_prepend() {
     cp -v -f ${S}/arch/arm/configs/mako_defconfig ${WORKDIR}/defconfig
 }
 
-SRCREV = "c2beb2ae393193c10cdd4446f98127dbf4b06768"
+SRCREV = "c472fe80340f89c2b2c9498dd6e78e6317f4b389"
 
 KV = "3.4.0"
 PV = "${KV}+gitr${SRCPV}"

--- a/meta-oneplus/recipes-kernel/linux/linux-oneplus-onyx_git.bb
+++ b/meta-oneplus/recipes-kernel/linux/linux-oneplus-onyx_git.bb
@@ -17,7 +17,7 @@ ANDROID_BOOTIMG_TAGS_RAM_BASE = "0x00000100"
 inherit kernel_android
 
 SRC_URI = " \
-  git://github.com/corpuscle/android_kernel_oneplus_onyx.git;branch=cm-14.1-los \
+  git://github.com/corpuscle/android_kernel_oneplus_onyx.git;branch=cm-14.1-wip \
 "
 S = "${WORKDIR}/git"
 
@@ -25,7 +25,7 @@ do_configure_prepend() {
     cp -v -f ${S}/arch/arm/configs/lineageos_onyx_defconfig ${WORKDIR}/defconfig
 }
 
-SRCREV = "79e6735d4a7deae28426e756c8b87f58e27393d6"
+SRCREV = "92ff3b6319710a1bafc9c029c10f91cc05cbef37"
 
 KV = "3.4.0"
 PV = "${KV}+gitr${SRCPV}"


### PR DESCRIPTION
Bump to latest revisions that include the required patches for GCC8.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>