### PR TITLE
libhybris: use older SRCREV for tenderloin

### DIFF
--- a/meta-hp/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-hp/recipes-core/libhybris/libhybris_git.bbappend
@@ -1,0 +1,3 @@
+# fix libhybris revision to an older version, as there is a serious memory leak
+# in more recent ones, which still needs to be analyzed
+SRCREV_tenderloin = "3beca8ad9246e3fce3c47ef978c3b07f6c04284a"


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>