### PR TITLE
meta-android: Add android-headers-halium_8.1

### DIFF
--- a/meta-android/recipes-android/android-headers/android-headers-halium_8.1.bb
+++ b/meta-android/recipes-android/android-headers/android-headers-halium_8.1.bb
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+require recipes-android/android-headers/android-headers.inc
+
+PV = "8.1+gitr${SRCPV}"
+SRCREV = "9d2f25e13880932d5172c812f4706068c7a178bb"
+
+SRC_URI = "git://github.com/halium/android-headers.git;branch=halium-8.1;protocol=git"
+ANDROID_API = "27"
+S = "${WORKDIR}"


### PR DESCRIPTION
For the WIP Halium 8.1 builds, already add the recipe for the required Android 8.1 headers, so the integration will be easier going forward.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>