### PR TITLE
meta-qualcomm-modems: add layer dedicated to Qualcomm modem support

### DIFF
--- a/meta-qualcomm-modems/conf/layer.conf
+++ b/meta-qualcomm-modems/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, append to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have a recipes directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "qualcomm-modems-layer"
+BBFILE_PATTERN_qualcomm-modems-layer := "^${LAYERDIR}/"
+BBFILE_PRIORITY_qualcomm-modems-layer = "7"
+
+LAYERDEPENDS_qualcomm-modems-layer = "core openembedded-layer"
+
+LAYERSERIES_COMPAT_qualcomm-modems-layer = "zeus"

--- a/meta-qualcomm-modems/recipes-core/udev/udev-extraconf/70-qmi-modem.rules
+++ b/meta-qualcomm-modems/recipes-core/udev/udev-extraconf/70-qmi-modem.rules
@@ -1,0 +1,12 @@
+SUBSYSTEM!="rpmsg", GOTO="qcom_rpmsg_end"
+
+# symlink rpmsg endpoints under useful names
+ATTR{name}=="DATA5_CNTL", SYMLINK+="modem"
+
+# open SMD channels when the remoteproc comes up
+KERNEL!="rpmsg_ctrl[0-9]*", GOTO="qcom_rpmsg_end"
+ATTRS{rpmsg_name}!="modem", GOTO="qcom_rpmsg_end"
+
+ACTION=="add", RUN+="/usr/bin/rpmsgexport /dev/$name DATA5_CNTL"
+
+LABEL="qcom_rpmsg_end"

--- a/meta-qualcomm-modems/recipes-core/udev/udev-extraconf/70-qmi-ofono.rules
+++ b/meta-qualcomm-modems/recipes-core/udev/udev-extraconf/70-qmi-ofono.rules
@@ -1,0 +1,2 @@
+SYMLINK=="modem", SUBSYSTEM=="smdpkt",   ENV{OFONO_DRIVER}="gobi"
+SYMLINK=="modem", SUBSYSTEM=="rpmsg",    ENV{OFONO_DRIVER}="gobi"

--- a/meta-qualcomm-modems/recipes-core/udev/udev-extraconf/70-qmi-qcom_rmtfs.rules
+++ b/meta-qualcomm-modems/recipes-core/udev/udev-extraconf/70-qmi-qcom_rmtfs.rules
@@ -1,0 +1,9 @@
+# check for mmcblk0 so that an SD card or something doesn't match
+KERNEL!="mmcblk0p[0-9]*", GOTO="qcom_rmtfs_end"
+
+ENV{ID_PART_ENTRY_NAME}=="modemst1",    SYMLINK+="disk/qcom_rmtfs/modem_fs1"
+ENV{ID_PART_ENTRY_NAME}=="modemst2",    SYMLINK+="disk/qcom_rmtfs/modem_fs2"
+ENV{ID_PART_ENTRY_NAME}=="fsc",         SYMLINK+="disk/qcom_rmtfs/modem_fsc"
+ENV{ID_PART_ENTRY_NAME}=="fsg",         SYMLINK+="disk/qcom_rmtfs/modem_fsg"
+
+LABEL="qcom_rmtfs_end"

--- a/meta-qualcomm-modems/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-qualcomm-modems/recipes-core/udev/udev-extraconf_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+

--- a/meta-qualcomm-modems/recipes-support/libsmdpkt-wrapper/libsmdpkt-wrapper.bb
+++ b/meta-qualcomm-modems/recipes-support/libsmdpkt-wrapper/libsmdpkt-wrapper.bb
@@ -1,0 +1,30 @@
+SUMMARY = "Wrapper to get ofonod and qmicli working on smdpkt devices (MSM kernel's SMD)"
+HOMEPAGE = "https://github.com/scintill/libsmdpkt_wrapper"
+LICENSE = "GPL-3.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
+
+DEPENDS = "util-linux"
+
+PV = "0.1"
+
+SRC_URI = "git://github.com/scintill/libsmdpkt_wrapper.git;protocol=git;branch=master"
+
+SRCREV = "1b951eca8a6d2690f6ce146d5f92338e071b7156"
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE = "LDFLAGS='${LDFLAGS}'"
+
+do_configure() {
+    rm -f ${S}/libsmdpkt_wrapper.so
+}
+
+do_compile() {
+    ${CC} -shared -fPIC -Wall -Wextra -Werror -std=c99 -O2 ${LDFLAGS} wrapper.c -o libsmdpkt_wrapper.so
+}
+
+do_install() {
+    mkdir -p ${D}${libdir}/preload
+    install -Dm644 ${S}/libsmdpkt_wrapper.so ${D}${libdir}/preload/libsmdpkt_wrapper.so
+}
+
+FILES_${PN} = "${libdir}/preload/libsmdpkt_wrapper.so"

--- a/meta-qualcomm-modems/recipes-support/qmic/qmic.bb
+++ b/meta-qualcomm-modems/recipes-support/qmic/qmic.bb
@@ -1,0 +1,21 @@
+SUMMARY = "QMI IDL compiler"
+HOMEPAGE = "https://github.com/andersson/qmic"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ca25dbf5ebfc1a058bfc657c895aac2f"
+
+DEPENDS = "util-linux"
+
+PV = "1.0"
+
+SRC_URI = "git://github.com/andersson/qmic.git;protocol=git;branch=master"
+
+EXTRA_OEMAKE = "prefix=${prefix} bindir=${bindir} libdir=${libdir} includedir=${includedir} servicedir=${systemd_system_unitdir} LDFLAGS='${LDFLAGS}'"
+
+SRCREV = "815dd495eb087b3b3ea02a8ed43716efac43db1c"
+S = "${WORKDIR}/git"
+
+BBCLASSEXTEND = "native"
+
+do_install() {
+    oe_runmake install 'DESTDIR=${D}'
+}

--- a/meta-qualcomm-modems/recipes-support/qrtr/qrtr.bb
+++ b/meta-qualcomm-modems/recipes-support/qrtr/qrtr.bb
@@ -1,0 +1,25 @@
+SUMMARY = "QIPCRTR Name Service"
+HOMEPAGE = "https://github.com/andersson/rpmsgexport"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=15329706fbfcb5fc5edcc1bc7c139da5"
+
+DEPENDS = "util-linux"
+
+PV = "1.0"
+
+SRC_URI = "git://github.com/andersson/qrtr.git;protocol=git;branch=master"
+
+SRCREV = "cd6bedd5d00f211e6c1e3803ff2f9f53c246435e"
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE = "prefix=${prefix} bindir=${bindir} libdir=${libdir} includedir=${includedir} servicedir=${systemd_system_unitdir} LDFLAGS='${LDFLAGS}'"
+
+do_install() {
+    oe_runmake install 'DESTDIR=${D}'
+}
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "${PN}-ns.service"
+
+inherit systemd
+FILES_${PN} += "${systemd_system_unitdir}"

--- a/meta-qualcomm-modems/recipes-support/rmtfs/rmtfs.bb
+++ b/meta-qualcomm-modems/recipes-support/rmtfs/rmtfs.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Qualcomm Remote Filesystem Service Implementation"
+HOMEPAGE = "https://github.com/andersson/rmtfs"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ca25dbf5ebfc1a058bfc657c895aac2f"
+
+DEPENDS = "util-linux qrtr qmic-native udev"
+
+PV = "1.0"
+
+SRC_URI = "git://github.com/andersson/rmtfs.git;protocol=git;branch=master"
+
+EXTRA_OEMAKE = "prefix=${prefix} bindir=${bindir} libdir=${libdir} includedir=${includedir} servicedir=${systemd_system_unitdir}"
+
+SRCREV = "df6c19d0330d251af0a7c812bf5ddb847962ce2c"
+S = "${WORKDIR}/git"
+
+inherit systemd
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "${PN}.service"
+
+do_install() {
+    oe_runmake install 'DESTDIR=${D}'
+}
+
+FILES_${PN} += "${systemd_system_unitdir}"

--- a/meta-qualcomm-modems/recipes-support/rpmsgexport/rpmsgexport.bb
+++ b/meta-qualcomm-modems/recipes-support/rpmsgexport/rpmsgexport.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Qualcomm Remote Filesystem Service Implementation"
+HOMEPAGE = "https://github.com/andersson/rpmsgexport"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ff273e1fd41fa52668171e0817c89724"
+
+DEPENDS = "util-linux udev"
+
+PV = "1.0"
+
+SRC_URI = "git://github.com/andersson/rpmsgexport.git;protocol=git;branch=master"
+
+EXTRA_OEMAKE = "prefix=${prefix} bindir=${bindir} libdir=${libdir} includedir=${includedir} servicedir=${systemd_system_unitdir} LDFLAGS='${LDFLAGS}'"
+
+SRCREV = "324d88d668f36c6a5e6a9c2003a050b8a5a3cd60"
+S = "${WORKDIR}/git"
+
+do_install() {
+    oe_runmake install 'DESTDIR=${D}'
+}


### PR DESCRIPTION
In this layer are recipes related to qualcomm modems, like
QMI and SMD communication support.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>