### PR TITLE
libhybris: append CFLAGS for rosy

### DIFF
--- a/meta-xiaomi/recipes-core/libhybris/libhybris_%.bbappend
+++ b/meta-xiaomi/recipes-core/libhybris/libhybris_%.bbappend
@@ -1,5 +1,8 @@
 CFLAGS_append_mido = " -DQTI_BSP -DQCOM_HARDWARE"
 CXXFLAGS_append_mido = " -DQTI_BSP -DQCOM_HARDWARE"
 
+CFLAGS_append_rosy = " -DQTI_BSP -DQCOM_HARDWARE"
+CXXFLAGS_append_rosy = " -DQTI_BSP -DQCOM_HARDWARE"
+
 CFLAGS_append_tissot = " -DQTI_BSP -DQCOM_HARDWARE"
 CXXFLAGS_append_tissot = " -DQTI_BSP -DQCOM_HARDWARE"


### PR DESCRIPTION
This should be here too, though it doesn't seem to impact the build or
runtime.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>