### PR TITLE
android-headers: Add recipe for Android 9.0 headers

### DIFF
--- a/meta-android/recipes-android/android-headers/android-headers-halium_9.0.bb
+++ b/meta-android/recipes-android/android-headers/android-headers-halium_9.0.bb
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+require recipes-android/android-headers/android-headers.inc
+
+PV = "9.0+gitr${SRCPV}"
+SRCREV = "00543b4ff3f56a9f96be336df276365aef46f8a2"
+
+SRC_URI = "git://github.com/halium/android-headers.git;branch=halium-9.0;protocol=git"
+ANDROID_API = "28"
+S = "${WORKDIR}"


### PR DESCRIPTION
So we can start trying to get something working with Halium 9.0 as well.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>