### PR TITLE
lxc-config: Update to reflect changes as per LXC 2.1

### DIFF
--- a/meta-android/recipes-core/android-system/android-system/lxc-config
+++ b/meta-android/recipes-core/android-system/android-system/lxc-config
@@ -1,27 +1,11 @@
-# (c) 2013 Canonical LTD.
-#
-# This program is free software: you can redistribute it and/or modify it
-# under the terms of the the GNU General Public License version 3, as
-# published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranties of
-# MERCHANTABILITY, SATISFACTORY QUALITY or FITNESS FOR A PARTICULAR
-# PURPOSE.  See the applicable version of the GNU Lesser General Public
-# License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+lxc.rootfs.path = /var/lib/lxc/android/rootfs
+lxc.uts.name = armhf
 
-lxc.rootfs = /var/lib/lxc/android/rootfs
-lxc.utsname = armhf
-
-lxc.devttydir = lxc
-lxc.tty = 4
-lxc.pts = 1024
+lxc.tty.dir = lxc
+lxc.tty.max  = 4
+lxc.pty.max = 1024
 lxc.arch = armhf
 lxc.cap.drop = mac_admin mac_override
-lxc.pivotdir = lxc_putold
 
 lxc.hook.pre-start = /var/lib/lxc/android/pre-start.sh
 lxc.hook.post-stop = /var/lib/lxc/android/post-stop.sh
@@ -29,4 +13,4 @@ lxc.hook.post-stop = /var/lib/lxc/android/post-stop.sh
 # We have to share the network namespace with the host as otherwise the RIL
 # service doesn't have access to the network interfaces it needs to setup
 # a data connection.
-lxc.network.type = none
+lxc.net.0.type = none


### PR DESCRIPTION
LXC 2.1 changed the name of some of the config items as per https://discuss.linuxcontainers.org/t/lxc-2-1-has-been-released/487. Update them to reflect these changes. Based upon: https://github.com/Halium/lxc-android/pull/15/files

Dropped the license part since it doesn't seem common to include in the config file.

Tested on Hammerhead, Tenderloin & Mido. 

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>