### PR TITLE
linux-hp-tenderloin: fix CMDLINE for tenderloin

### DIFF
--- a/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin.bb
+++ b/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin.bb
@@ -2,11 +2,11 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "tenderloin"
 
-PV = "20210309-2"
+PV = "20210416-1"
 
 SRC_URI = "http://build.webos-ports.org/halium-luneos-9.0/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[md5sum] = "e92df1df9da4907fd85d2648b5574c17"
-SRC_URI[sha256sum] = "5caa0dfcc4960f29d6d9f7389637823272a114681e08bbdfab418beee04f12de"
+SRC_URI[md5sum] = "aaf136a0ad268aa2de9b0bc6c0a6336b"
+SRC_URI[sha256sum] = "257f5d1db3e048ef7f30833315a906ba26f767e643b6c3e49c3ccae706dfd1df"
 
 # For Android 9+, it's highly recommended to use a rootfs system image
 ANDROID_SYSTEM_IMAGE_DESTNAME = "android-rootfs.img"

--- a/meta-hp/recipes-kernel/linux/linux-hp-tenderloin_git.bb
+++ b/meta-hp/recipes-kernel/linux/linux-hp-tenderloin_git.bb
@@ -10,6 +10,8 @@ SRC_URI = " \
 "
 S = "${WORKDIR}/git"
 
+CMDLINE = "androidboot.selinux=permissive  androidboot.hardware=tenderloin"
+
 do_configure_prepend() {
     cp -v -f ${S}/arch/arm/configs/tenderloin_android_defconfig ${WORKDIR}/defconfig
 }


### PR DESCRIPTION
The android init need the value of androidboot.hardware.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>