### PR TITLE
android-system: handle case when there is no persist partition

### DIFF
--- a/meta-android/recipes-core/android-system/android-system/pre-start.sh
+++ b/meta-android/recipes-core/android-system/android-system/pre-start.sh
@@ -9,9 +9,12 @@ if [ -e /android/init ]; then
 		desired_mount=${2/\/android/}
 		mount --bind $2 $LXC_ROOTFS_PATH/$desired_mount
 	done
-	
+
+	rm -rf /dev/__properties__
 	mkdir -p /dev/__properties__
-	mkdir -p /mnt/vendor/persist && mount /dev/disk/by-partlabel/persist /mnt/vendor/persist
+	if [ -e /dev/disk/by-partlabel/persist ]; then
+		mkdir -p /mnt/vendor/persist && mount /dev/disk/by-partlabel/persist /mnt/vendor/persist
+	fi
 else
 	for mountpoint in /android/*; do
 		mount_name=$(basename $mountpoint)


### PR DESCRIPTION
On tenderloin, there is no persist partition; so avoid having the
script fail in that case.
Also, make sure /dev/__properties__ is cleaned up before we start lxc.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>