### PR TITLE
linux-xiaomi-mido: bump SRCREV to fix build with gcc-11

### DIFF
--- a/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-mido_git.bb
+++ b/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-mido_git.bb
@@ -23,7 +23,7 @@ do_configure_prepend() {
     cp -v -f ${S}/arch/arm64/configs/mido_defconfig ${WORKDIR}/defconfig
 }
 
-SRCREV = "b0511d20d6fcb33d14666e18412eea4f8fd34fb3"
+SRCREV = "de9f779437b558413f61610a3b25ed13ba25df4d"
 
 KV = "4.9.188"
 PV = "${KV}+gitr${SRCPV}"


### PR DESCRIPTION
$ git log --oneline b0511d20d6fcb33d14666e18412eea4f8fd34fb3..de9f779437b558413f61610a3b25ed13ba25df4d | tee
de9f779437b5 techpack: audio: Drop -Werror
bbd0a12d32ba arm64: Remove redundant mov from LL/SC cmpxchg
b82f8f648312 techpack: Fix incorrect if statements detected with gcc-11
72ae01702246 scripts/dtc: Remove redundant YYLOC global declaration

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>