### PR TITLE
tenderloin-ath6kl-module: delay module loading

### DIFF
--- a/meta-hp/recipes-core/systemd/systemd-machine-units/tenderloin/tenderloin-ath6kl-module.service
+++ b/meta-hp/recipes-core/systemd/systemd-machine-units/tenderloin/tenderloin-ath6kl-module.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Load the ath6kl WiFi kernel module
+After=android-system.service
+Requires=android-system.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Wait until ueventd from Halium is started, to help with firmware loading

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>