### PR TITLE
android-system-image: Update SRC_URI to GitHub

### DIFF
--- a/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin.bb
+++ b/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin.bb
@@ -4,7 +4,7 @@ COMPATIBLE_MACHINE = "tenderloin"
 
 PV = "20210506-2"
 
-SRC_URI = "http://build.webos-ports.org/halium-luneos-9.0/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
 SRC_URI[sha256sum] = "800855aa74f752c774312c48143cc158d8d5e32a281f7f978851a0679350fe9b"
 
 # For Android 9+, it's highly recommended to use a rootfs system image

--- a/meta-leeco/recipes-core/android-system-image/android-system-image-s2.bb
+++ b/meta-leeco/recipes-core/android-system-image/android-system-image-s2.bb
@@ -4,7 +4,7 @@ COMPATIBLE_MACHINE = "s2"
 
 PV = "20210204-1"
 
-SRC_URI = "http://build.webos-ports.org/halium-luneos-7.1/halium-luneos-7.1-${PV}-${MACHINE}.tar.bz2"
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-7.1-${PV}-${MACHINE}.tar.bz2/halium-luneos-7.1-${PV}-${MACHINE}.tar.bz2"
 SRC_URI[md5sum] = "b5f2b8bbfcde7bd02da1a806669f397e"
 SRC_URI[sha256sum] = "1292e32fc6e036254757a25901f3b8b9d5a1dfb13cf336ce61d0df95d2d62aef"
 

--- a/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead.bb
@@ -2,10 +2,14 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "hammerhead"
 
-PV = "20210506-4"
+# PV went backwards due to loss of image on file server. Using previous build from backup.
+# PV = "20210506-4"
 
-SRC_URI = "http://build.webos-ports.org/halium-luneos-9.0/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[sha256sum] = "c4f285da5c8239d836d518519848b094230de426055c339cabd8b139adeb6223"
+PV = "20210506-3"
+
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
+# SRC_URI[sha256sum] = "c4f285da5c8239d836d518519848b094230de426055c339cabd8b139adeb6223"
+SRC_URI[sha256sum] = "83d3e7388a5e65c33c48e6104a38449c349bffbc486db1b378850baa2f4fdfb8"
 
 # For Android 9+, it's highly recommended to use a rootfs system image
 ANDROID_SYSTEM_IMAGE_DESTNAME = "android-rootfs.img"

--- a/meta-lg/recipes-core/android-system-image/android-system-image-mako.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-mako.bb
@@ -2,10 +2,14 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "mako"
 
-PV = "20210506-2"
+# PV went backwards due to loss of image on file server. Using previous build from backup.
+# PV = "20210506-2"
 
-SRC_URI = "http://build.webos-ports.org/halium-luneos-9.0/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[sha256sum] = "d6bb53f9e886428faeb589c61b98b5e0345789b6587cb0b01a3e34cb546f92fb"
+PV = "20210420-2"
 
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
+# SRC_URI[sha256sum] = "d6bb53f9e886428faeb589c61b98b5e0345789b6587cb0b01a3e34cb546f92fb"
+SRC_URI[sha256sum] = "9bf006c6dd16d37da34de665885b30aaca6accbf104405db156372f09ae66371"
+ 
 # For Android 9+, it's highly recommended to use a rootfs system image
 ANDROID_SYSTEM_IMAGE_DESTNAME = "android-rootfs.img"

--- a/meta-volla/recipes-core/android-system-image/android-system-image-yggdrasil.bb
+++ b/meta-volla/recipes-core/android-system-image/android-system-image-yggdrasil.bb
@@ -4,7 +4,7 @@ COMPATIBLE_MACHINE = "yggdrasil"
 
 PV = "20210112-herrie"
 
-SRC_URI = "http://build.webos-ports.org/halium-luneos-9.0-uploaded/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
 SRC_URI[md5sum] = "b03137c922634deafa778240622a2f1b"
 SRC_URI[sha256sum] = "e4d60d5687c2ece1829c82c70c2d8abbe0e6b7a1ecb236fb137979af9c8dcf8a"
 

--- a/meta-xiaomi/recipes-core/android-system-image/android-system-image-mido.bb
+++ b/meta-xiaomi/recipes-core/android-system-image/android-system-image-mido.bb
@@ -4,7 +4,7 @@ COMPATIBLE_MACHINE = "mido"
 
 PV = "20210506-2"
 
-SRC_URI = "http://build.webos-ports.org/halium-luneos-9.0/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
 SRC_URI[sha256sum] = "af9deead686663ceab1717fe3d76ade19207e91191761eb23778bee7107de994"
 
 ANDROID_SYSTEM_IMAGE_DESTNAME = "android-rootfs.img"

--- a/meta-xiaomi/recipes-core/android-system-image/android-system-image-oxygen.bb
+++ b/meta-xiaomi/recipes-core/android-system-image/android-system-image-oxygen.bb
@@ -4,7 +4,7 @@ COMPATIBLE_MACHINE = "oxygen"
 
 PV = "20201219-1"
 
-SRC_URI = "http://build.webos-ports.org/halium-luneos-7.1/halium-luneos-7.1-${PV}-${MACHINE}.tar.bz2"
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-7.1-${PV}-${MACHINE}.tar.bz2/halium-luneos-7.1-${PV}-${MACHINE}.tar.bz2"
 
 SRC_URI[md5sum] = "92a3bdb64c5a6fff0735bb40024abcad"
 SRC_URI[sha256sum] = "7ee780041cdbe95933444f1c3937b38c1de9fb45b8a6cf328e0b95e6e8b47850"

--- a/meta-xiaomi/recipes-core/android-system-image/android-system-image-rosy.bb
+++ b/meta-xiaomi/recipes-core/android-system-image/android-system-image-rosy.bb
@@ -2,11 +2,14 @@ require recipes-core/android-system-image/android-system-image.inc
 
 COMPATIBLE_MACHINE = "^rosy$"
 
-PV = "20210506-2"
+# PV went backwards due to loss of image on file server. Using previous build from backup.
+# PV = "20210506-2"
 
-SRC_URI = "http://build.webos-ports.org/halium-luneos-9.0/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[sha256sum] = "24ff90a6c790e360df35306a6e0d2f572f7a1c4ebdf9de9c3bfc371465ccfed5"
+PV = "20210219-1"
+
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
+# SRC_URI[sha256sum] = "24ff90a6c790e360df35306a6e0d2f572f7a1c4ebdf9de9c3bfc371465ccfed5"
+SRC_URI[sha256sum] = "6490047a5ebc33f1328b1af63bb530a8be4bdfe919be278f3fa8a5049a6f7b50"
 
 # For Android 9+, it's highly recommended to use a rootfs system image
 ANDROID_SYSTEM_IMAGE_DESTNAME = "android-rootfs.img"
-

--- a/meta-xiaomi/recipes-core/android-system-image/android-system-image-sagit.bb
+++ b/meta-xiaomi/recipes-core/android-system-image/android-system-image-sagit.bb
@@ -4,9 +4,7 @@ COMPATIBLE_MACHINE = "sagit"
 
 PV = "20210202-herrie"
 
-SRC_URI = "http://build.webos-ports.org/halium-luneos-9.0-uploaded/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
-
-SRC_URI[md5sum] = "7da9926a1a90fbedcb8f96b6f8c8b7df"
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
 SRC_URI[sha256sum] = "552628e0944a8e677b886278a38fac3f60f1ca62a9358d61dba3a546eb1e87da"
 
 ANDROID_SYSTEM_IMAGE_DESTNAME = "android-rootfs.img"

--- a/meta-xiaomi/recipes-core/android-system-image/android-system-image-tissot.bb
+++ b/meta-xiaomi/recipes-core/android-system-image/android-system-image-tissot.bb
@@ -4,7 +4,7 @@ COMPATIBLE_MACHINE = "tissot"
 
 PV = "20210517-3"
 
-SRC_URI = "http://build.webos-ports.org/halium-luneos-9.0/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
 SRC_URI[sha256sum] = "e9c776d5c60a26ef86ddb4a1c6e91cf0d659f20396be01a2784ebc75825fc377"
 
 ANDROID_SYSTEM_IMAGE_DESTNAME = "android-rootfs.img"


### PR DESCRIPTION
Since the build servers are still down, I've moved the halium images I had locally to GitHub and updated the recipes.

For Hammerhead, Mako and Rosy I didn't have the exact images anymore, so those went backwards a little. I commented the old ones out, so we have them as reference.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>