### PR TITLE
android-headers.inc: Make it work with Android 11.0 headers

### DIFF
--- a/meta-android/recipes-android/android-headers/android-headers.inc
+++ b/meta-android/recipes-android/android-headers/android-headers.inc
@@ -17,6 +17,7 @@ S = "${WORKDIR}/git"
 do_configure() {
     :
 }
+
 do_compile() {
     :
 }
@@ -36,6 +37,11 @@ do_install() {
     fi
 
     install -d ${D}${libdir}/pkgconfig
-    install -m 0644 ${S}/android-headers.pc ${D}${libdir}/pkgconfig/android-headers.pc
+    if [ -f ${S}/android-headers.pc ] ; then
+        install -m 0644 ${S}/android-headers.pc ${D}${libdir}/pkgconfig/android-headers.pc
+    elif [ -f ${S}/android-headers.pc.in ] ; then
+        install -m 0644 ${S}/android-headers.pc.in ${D}${libdir}/pkgconfig/android-headers.pc
+    fi
+    
     ln -s android ${D}${includedir}/android-${ANDROID_API}
 }

--- a/meta-android/recipes-android/android-headers/android-headers.inc
+++ b/meta-android/recipes-android/android-headers/android-headers.inc
@@ -40,7 +40,7 @@ do_install() {
     if [ -f ${S}/android-headers.pc ] ; then
         install -m 0644 ${S}/android-headers.pc ${D}${libdir}/pkgconfig/android-headers.pc
     elif [ -f ${S}/android-headers.pc.in ] ; then
-        install -m 0644 ${S}/android-headers.pc.in ${D}${libdir}/pkgconfig/android-headers.pc
+        sed -e "s;@includedir@;${includedir}/android;g" ${S}/android-headers.pc.in > ${D}${libdir}/pkgconfig/android-headers.pc
     fi
     
     ln -s android ${D}${includedir}/android-${ANDROID_API}


### PR DESCRIPTION
Android 11 provides a android-headers.pc.in instead of a android-headers.in file. Make it work in both cases.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>