### PR TITLE
tenderloin.conf: Add KERNEL_DEVICETREE and move values around into lo…

### DIFF
--- a/meta-hp/conf/machine/tenderloin.conf
+++ b/meta-hp/conf/machine/tenderloin.conf
@@ -9,8 +9,6 @@ TARGET_ARCH = "arm"
 PREFERRED_PROVIDER_virtual/kernel = "linux-hp-tenderloin"
 MACHINE_KERNEL_PR = "r0"
 
-KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
-
 MACHINE_FEATURES = "kernel26 apm alsa bluetooth gps usbgadget usbhost wifi vfat ext2 keyboard"
 # The Touchpad 4G is basically the same as the Touchpad but includes a cellular modem.
 # To support that as well add the MACHINE_FEATURES cellular here to let the upper layers
@@ -46,12 +44,15 @@ MACHINE_EXTRA_RDEPENDS = " \
     lvm2 \
 "
 
-KERNEL_IMAGETYPE = "uImage"
-IMAGE_FSTYPES += "tar.gz"
-IMAGE_ROOTFS_EXTRA_SPACE = "200000"
-
 UBOOT_ENTRYPOINT = "41000000"
 UBOOT_LOADADDRESS = "41000000"
+
+KERNEL_DEVICETREE = "qcom-apq8060-tenderloin.dtb"
+KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
+KERNEL_IMAGETYPE = "uImage"
+
+IMAGE_FSTYPES += "tar.gz"
+IMAGE_ROOTFS_EXTRA_SPACE = "200000"
 
 SERIAL_CONSOLE = "115200 ttyMSM0"
 


### PR DESCRIPTION
…gical order

We forgot to specify KERNEL_DEVICETREE required to add DTB to uImage.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>