### PR TITLE
android-system-image-hammerhead-halium: Update COMPATIBLE_MACHINE and…

### DIFF
--- a/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead-halium.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead-halium.bb
@@ -1,11 +1,11 @@
 require recipes-core/android-system-image/android-system-image.inc
 
-COMPATIBLE_MACHINE = "hammerhead"
+COMPATIBLE_MACHINE = "hammerhead-halium"
 
-PV = "20210506-4"
+PV = "20230127-1"
 
 SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
-SRC_URI[sha256sum] = "c4f285da5c8239d836d518519848b094230de426055c339cabd8b139adeb6223"
+SRC_URI[sha256sum] = "a3b058dd2bafd6d9af661b03f54cb35e115dd5601624534e34a271bfde1b1e46"
 
 # For Android 9+, it's highly recommended to use a rootfs system image
 ANDROID_SYSTEM_IMAGE_DESTNAME = "android-rootfs.img"


### PR DESCRIPTION
… Halium image

Fixes:

Apr 28 17:42:45 hammerhead-halium surface-manager.sh[2246]: library "/vendor/lib/egl/libGLESv2S3D_adreno.so" not found

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>