### PR TITLE
*.patch: add Upstream-Status where missing

### DIFF
--- a/meta-android/recipes-android/android-headers/android-headers-halium/0001-Revert-hwc-remove-qcom_bsp-since-it-causes-trouble-w.patch
+++ b/meta-android/recipes-android/android-headers/android-headers-halium/0001-Revert-hwc-remove-qcom_bsp-since-it-causes-trouble-w.patch
@@ -5,6 +5,7 @@ Subject: [PATCH 1/2] Revert "[hwc] remove qcom_bsp since it causes trouble
  with libhybris"
 
 This reverts commit c5afd16f803a1ae5f7f1a5962a6cc14f237dd002.
+Upstream-Status: Pending
 ---
  hardware/hwcomposer.h | 5 +++++
  1 file changed, 5 insertions(+)

--- a/meta-android/recipes-android/android-headers/android-headers-halium/0002-Revert-Use-AOSP-version-of-gralloc.h.patch
+++ b/meta-android/recipes-android/android-headers/android-headers-halium/0002-Revert-Use-AOSP-version-of-gralloc.h.patch
@@ -4,6 +4,7 @@ Date: Thu, 14 Sep 2017 12:53:14 +0200
 Subject: [PATCH 2/2] Revert "Use AOSP version of gralloc.h"
 
 This reverts commit 0379b04e012b491ee87df9d129cc80f203dfb787.
+Upstream-Status: Pending
 ---
  hardware/gralloc.h | 32 ++++++++++++++++++++++++++++++++
  1 file changed, 32 insertions(+)

--- a/meta-android/recipes-android/suspend-blocker/suspend-blocker/0001-suspend-blocker.c-update-json.h-path.patch
+++ b/meta-android/recipes-android/suspend-blocker/suspend-blocker/0001-suspend-blocker.c-update-json.h-path.patch
@@ -7,6 +7,7 @@ Subject: [PATCH] suspend-blocker.c: update json.h path
   and doesn't install json -> json-c symlink
 
 Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+Upstream-Status: Pending
 ---
  suspend-blocker.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/meta-android/recipes-core/base-passwd/base-passwd/change-android-group-ids.patch
+++ b/meta-android/recipes-core/base-passwd/base-passwd/change-android-group-ids.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 --- group.master-orig	2014-11-27 11:20:41.535052932 +0100
 +++ group.master	2014-11-27 11:21:57.607291088 +0100
 @@ -12,7 +12,7 @@

--- a/meta-android/recipes-core/libhybris/libhybris/0001-eglplatform.h-take-MESA_EGL_NO_X11_HEADERS-into-acco.patch
+++ b/meta-android/recipes-core/libhybris/libhybris/0001-eglplatform.h-take-MESA_EGL_NO_X11_HEADERS-into-acco.patch
@@ -10,7 +10,7 @@ As before commit d31230d854c7041a48be64047b939b09dd23f580 ,
 take into account MESA_EGL_NO_X11_HEADERS to exclude X11.
 
 Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
-Upstream-Status: Pending
+Upstream-Status: Submitted [https://github.com/libhybris/libhybris/pull/530]
 ---
  hybris/include/EGL/eglplatform.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/meta-android/recipes-core/libhybris/libhybris/0001-eglplatform.h-take-MESA_EGL_NO_X11_HEADERS-into-acco.patch
+++ b/meta-android/recipes-core/libhybris/libhybris/0001-eglplatform.h-take-MESA_EGL_NO_X11_HEADERS-into-acco.patch
@@ -10,6 +10,7 @@ As before commit d31230d854c7041a48be64047b939b09dd23f580 ,
 take into account MESA_EGL_NO_X11_HEADERS to exclude X11.
 
 Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+Upstream-Status: Pending
 ---
  hybris/include/EGL/eglplatform.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/meta-android/recipes-support/invensense/invensense/0001-Implement-cmake-based-build-script-for-builds-outsid.patch
+++ b/meta-android/recipes-support/invensense/invensense/0001-Implement-cmake-based-build-script-for-builds-outsid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement cmake based build script for builds outside of
  Android
 
 Signed-off-by: Simon Busch <morphis@gravedo.de>
-Upstream-Status: Pending
+Upstream-Status: Inappropriate [upstream build toolchain is Android's not CMake]
 ---
  CMakeLists.txt       |    4 ++++
  mlsdk/CMakeLists.txt |   28 ++++++++++++++++++++++++++++

--- a/meta-android/recipes-support/invensense/invensense/0001-Implement-cmake-based-build-script-for-builds-outsid.patch
+++ b/meta-android/recipes-support/invensense/invensense/0001-Implement-cmake-based-build-script-for-builds-outsid.patch
@@ -5,6 +5,7 @@ Subject: [PATCH] Implement cmake based build script for builds outside of
  Android
 
 Signed-off-by: Simon Busch <morphis@gravedo.de>
+Upstream-Status: Pending
 ---
  CMakeLists.txt       |    4 ++++
  mlsdk/CMakeLists.txt |   28 ++++++++++++++++++++++++++++

--- a/meta-hp/recipes-core/initrdscripts/initramfs-scripts-halium/0001-tenderloin-Fix-userdata-mount-options.patch
+++ b/meta-hp/recipes-core/initrdscripts/initramfs-scripts-halium/0001-tenderloin-Fix-userdata-mount-options.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] tenderloin: Fix userdata mount options
 
 Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
 Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
-Upstream-Status: Pending
+Upstream-Status: Inappropriate [specific to tenderloin usecase]
 ---
  scripts/halium | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/meta-hp/recipes-core/initrdscripts/initramfs-scripts-halium/0001-tenderloin-Fix-userdata-mount-options.patch
+++ b/meta-hp/recipes-core/initrdscripts/initramfs-scripts-halium/0001-tenderloin-Fix-userdata-mount-options.patch
@@ -5,6 +5,7 @@ Subject: [PATCH] tenderloin: Fix userdata mount options
 
 Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
 Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+Upstream-Status: Pending
 ---
  scripts/halium | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/meta-lg/recipes-core/systemd/systemd/0001-systemd-hostnamed-disable-network-protection.patch
+++ b/meta-lg/recipes-core/systemd/systemd/0001-systemd-hostnamed-disable-network-protection.patch
@@ -3,7 +3,8 @@ From: Christophe Chapuis <chris.chapuis@gmail.com>
 Date: Mon, 5 Apr 2021 13:46:41 +0000
 Subject: [PATCH] systemd-hostnamed: disable network protection
 
-Upstream-Status: Pending
+Upstream-Status: Inappropriate [kernel version not supported anymore by systemd]
+
 ---
  units/systemd-hostnamed.service.in | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/meta-lg/recipes-core/systemd/systemd/0001-systemd-hostnamed-disable-network-protection.patch
+++ b/meta-lg/recipes-core/systemd/systemd/0001-systemd-hostnamed-disable-network-protection.patch
@@ -3,6 +3,7 @@ From: Christophe Chapuis <chris.chapuis@gmail.com>
 Date: Mon, 5 Apr 2021 13:46:41 +0000
 Subject: [PATCH] systemd-hostnamed: disable network protection
 
+Upstream-Status: Pending
 ---
  units/systemd-hostnamed.service.in | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)


### PR DESCRIPTION
There is new patch-status-noncore and patch-status-core QA check in oe-core:
https://git.openembedded.org/openembedded-core/commit/?id=76a685bfcf927593eac67157762a53259089ea8a

This is temporary work around just to hide _many_ warnings from optional patch-status-noncore.

This just added
Upstream-Status: Pending
everywhere without actually investigating what's the proper status. Don't follow this example for other layers.

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>