### PR TITLE
sensorfw: Split to keep layers clean

### DIFF
--- a/meta-android/recipes-support/sensorfw/sensorfw.bbappend
+++ b/meta-android/recipes-support/sensorfw/sensorfw.bbappend
@@ -1,0 +1,32 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+# Devices specific configuration and options for sensorfw go here
+
+do_install:append:halium() {
+    install -d ${D}${sysconfdir}/sensorfw/
+    install -m 0644 ${S}/config/sensord-hybris.conf ${D}${sysconfdir}/sensorfw/
+}
+
+EXTRA_QMAKEVARS_PRE:append:halium = "CONFIG+=autohybris "
+
+# Halium-9.0 devices use binder to communicate with sensors
+EXTRA_QMAKEVARS_PRE:append:hammerhead-halium = "CONFIG+=binder "
+EXTRA_QMAKEVARS_PRE:append:mako = "CONFIG+=binder "
+EXTRA_QMAKEVARS_PRE:append:mido = "CONFIG+=binder "
+EXTRA_QMAKEVARS_PRE:append:rosy = "CONFIG+=binder "
+EXTRA_QMAKEVARS_PRE:append:sagit = "CONFIG+=binder "
+EXTRA_QMAKEVARS_PRE:append:tissot = "CONFIG+=binder "
+EXTRA_QMAKEVARS_PRE:append:yggdrasil = "CONFIG+=binder "
+
+# Tenderloin here is an exception: sensorfw doesn't need to use Halium for the sensor
+EXTRA_QMAKEVARS_PRE:remove:tenderloin = "CONFIG+=autohybris "
+
+DEPENDS:append:halium = " libhybris virtual/android-headers libgbinder libglibutil "
+
+SRC_URI:append:tenderloin = " \
+    file://sensord-tenderloin.conf \
+"
+
+SRC_URI:append:hammerhead = " \
+    file://sensord-hammerhead.conf \
+"

--- a/meta-android/recipes-support/sensorfw/sensorfw/sensord-hammerhead.conf
+++ b/meta-android/recipes-support/sensorfw/sensorfw/sensord-hammerhead.conf
@@ -1,0 +1,23 @@
+[plugins]
+accelerometeradaptor = iiosensorsadaptor
+orientationadaptor = iiosensorsadaptor
+alsadaptor = iiosensorsadaptor
+magnetometeradaptor = iiosensorsadaptor
+gyroscopeadaptor = iiosensorsadaptor
+
+[accelerometer]
+input_match=mpu6515
+intervals = "200=>2000"
+default_interval=500
+transformation_matrix = "0,-1,0,-1,0,0,0,0,1"
+
+[als]
+input_match=apds9930
+intervals = "200=>2000"
+default_interval=500
+
+[gyroscope]
+input_match=mpu6515
+
+[magnetometer]
+input_match=ak8963

--- a/meta-android/recipes-support/sensorfw/sensorfw/sensord-tenderloin.conf
+++ b/meta-android/recipes-support/sensorfw/sensorfw/sensord-tenderloin.conf
@@ -1,0 +1,7 @@
+[plugins]
+accelerometeradaptor = accelerometeradaptor
+
+[accelerometer]
+input_match = lsm303dlh_acc_sysfs
+transformation_matrix = "1,0,0,0,1,0,0,0,1"
+


### PR DESCRIPTION
Add a bbappend for Android devices instead of polluting the main sensorfw recipe.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>