### PR TITLE
android-system-image: Fix name for hammerhead and tenderloin

### DIFF
--- a/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin-halium.bb
+++ b/meta-hp/recipes-core/android-system-image/android-system-image-tenderloin-halium.bb
@@ -4,7 +4,7 @@ COMPATIBLE_MACHINE = "tenderloin-halium"
 
 PV = "20210506-2"
 
-SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-tenderloin.tar.bz2/halium-luneos-9.0-${PV}-tenderloin.tar.bz2"
 SRC_URI[sha256sum] = "800855aa74f752c774312c48143cc158d8d5e32a281f7f978851a0679350fe9b"
 
 # For Android 9+, it's highly recommended to use a rootfs system image

--- a/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead-halium.bb
+++ b/meta-lg/recipes-core/android-system-image/android-system-image-hammerhead-halium.bb
@@ -4,7 +4,7 @@ COMPATIBLE_MACHINE = "hammerhead-halium"
 
 PV = "20230127-1"
 
-SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2/halium-luneos-9.0-${PV}-${MACHINE}.tar.bz2"
+SRC_URI = "https://github.com/webOS-ports/halium-images/releases/download/halium-luneos-9.0-${PV}-hammerhead.tar.bz2/halium-luneos-9.0-${PV}-hammerhead.tar.bz2"
 SRC_URI[sha256sum] = "a3b058dd2bafd6d9af661b03f54cb35e115dd5601624534e34a271bfde1b1e46"
 
 # For Android 9+, it's highly recommended to use a rootfs system image


### PR DESCRIPTION
After we suffixed the Android based machines with "-halium", the reference to ${MACHINE} will fail, therefore hardcode it to "hammerhead" and "tenderloin".

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>