### PR TITLE
initramfs-scripts-simple: grow rootfs when possible

### DIFF
--- a/meta-android/recipes-core/initrdscripts/initramfs-scripts-halium_1.0.bb
+++ b/meta-android/recipes-core/initrdscripts/initramfs-scripts-halium_1.0.bb
@@ -17,7 +17,7 @@ SRC_URI += " \
 
 S = "${WORKDIR}/git"
 
-SRCREV = "3d2006c66900ac70ef56dbb769aaba652f95b899"
+SRCREV = "0a2275aafe651d19e9eb3aa7a801c4d28550298f"
 
 do_install:append() {
     install -m 0755 ${WORKDIR}/init.sh ${D}/init

--- a/meta-mainline/recipes-core/initrdscripts/initramfs-scripts-simple_1.0.bb
+++ b/meta-mainline/recipes-core/initrdscripts/initramfs-scripts-simple_1.0.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 PACKAGES = "${PN}"
 
-RDEPENDS:${PN} = " iproute2 busybox-mdev "
+RDEPENDS:${PN} = " iproute2 busybox-mdev e2fsprogs e2fsprogs-resize2fs parted"
 
 SRC_URI = " \
   file://init.sh \


### PR DESCRIPTION
Add a function to test the remaing free space on the rootfs's device, and grow the rootfs partition to the maximum possible when there is space available.