### PR TITLE
meta-*: linux-*: use LINUX_VERSION variable instead of KV

### DIFF
--- a/meta-google/recipes-kernel/linux/linux-google-sargo_git.bb
+++ b/meta-google/recipes-kernel/linux/linux-google-sargo_git.bb
@@ -16,13 +16,13 @@ ANDROID_BOOTIMG_TAGS_RAM_BASE = "0x00000100"
 
 inherit kernel_android pkgconfig
 
-SRC_URI = "git://github.com/shr-distribution/linux.git;branch=sargo/${KV}/lune;protocol=https"
+SRC_URI = "git://github.com/shr-distribution/linux.git;branch=sargo/${LINUX_VERSION}/lune;protocol=https"
 SRCREV = "19e6d60c09c505aa2bf71194739243a56c847b82"
 
 S = "${WORKDIR}/git"
 
-KV = "4.9.124"
-PV = "${KV}+git"
+LINUX_VERSION = "4.9.124"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 

--- a/meta-hp/recipes-kernel/linux/linux-hp-tenderloin-halium_git.bb
+++ b/meta-hp/recipes-kernel/linux/linux-hp-tenderloin-halium_git.bb
@@ -20,8 +20,8 @@ KERNEL_OUTPUT ?= "${KERNEL_OUTPUT_DIR}/${KERNEL_IMAGETYPE}"
 
 SRCREV = "d4d4caea8869c3af31fd484012f4383cdf03b73d"
 
-KV = "3.4.113"
-PV = "${KV}+git"
+LINUX_VERSION = "3.4.113"
+PV = "${LINUX_VERSION}+git"
 
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr

--- a/meta-hp/recipes-kernel/linux/linux-hp-tenderloin_git.bb
+++ b/meta-hp/recipes-kernel/linux/linux-hp-tenderloin_git.bb
@@ -15,7 +15,6 @@ ANDROID_BOOTIMG_CMDLINE = "LUNEOS_NO_OUTPUT_REDIRECT console=ttyMSM0,115200,n8"
 
 inherit kernel
 
-LINUX_VERSION ?= "5.19-rc7"
 LINUX_VERSION_EXTENSION = "-luneos"
 #LINUX_KMETA_BRANCH = "yocto-${LINUX_VERSION}"
 LINUX_KMETA_BRANCH = "master"
@@ -32,8 +31,8 @@ SRC_URI = " \
 
 S = "${WORKDIR}/git"
 
-KV = "5.19-rc7"
-PV = "${KV}+git"
+LINUX_VERSION = "5.19-rc7"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 

--- a/meta-huawei/recipes-kernel/linux/linux-huawei-angler_git.bb
+++ b/meta-huawei/recipes-kernel/linux/linux-huawei-angler_git.bb
@@ -29,8 +29,8 @@ do_configure:prepend() {
 
 SRCREV = "3680219f6a6d5cf5079131de878f7ae3f3a28981"
 
-KV = "3.10.73"
-PV = "${KV}+git"
+LINUX_VERSION = "3.10.73"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 

--- a/meta-leeco/recipes-kernel/linux/linux-leeco-s2_git.bb
+++ b/meta-leeco/recipes-kernel/linux/linux-leeco-s2_git.bb
@@ -27,8 +27,8 @@ do_configure:prepend() {
 
 SRCREV = "5baf5356a021136340782582db601deff5f38149"
 
-KV = "3.10.84"
-PV = "${KV}+git"
+LINUX_VERSION = "3.10.84"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 

--- a/meta-lg/recipes-kernel/linux/linux-lg-hammerhead-halium_git.bb
+++ b/meta-lg/recipes-kernel/linux/linux-lg-hammerhead-halium_git.bb
@@ -25,7 +25,7 @@ do_configure:prepend() {
 
 SRCREV = "1c408a672099248ce8efec074f0f0d2a6f899f4c"
 
-KV = "3.4.0"
-PV = "${KV}+git"
+LINUX_VERSION = "3.4.0"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr

--- a/meta-lg/recipes-kernel/linux/linux-lg-hammerhead_git.bb
+++ b/meta-lg/recipes-kernel/linux/linux-lg-hammerhead_git.bb
@@ -34,7 +34,6 @@ SRC_URI = " \
 
 S = "${WORKDIR}/git"
 
-KV = "${LINUX_VERSION}"
-PV = "${KV}+git"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr

--- a/meta-lg/recipes-kernel/linux/linux-lg-mako_git.bb
+++ b/meta-lg/recipes-kernel/linux/linux-lg-mako_git.bb
@@ -25,7 +25,7 @@ do_configure:prepend() {
 
 SRCREV = "efe7b0dde2473dc83033cd92bc814d6cbfa929eb"
 
-KV = "3.4.113"
-PV = "${KV}+git"
+LINUX_VERSION = "3.4.113"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr

--- a/meta-motorola/recipes-kernel/linux/linux-motorola-athene_git.bb
+++ b/meta-motorola/recipes-kernel/linux/linux-motorola-athene_git.bb
@@ -25,8 +25,8 @@ do_configure:prepend() {
 
 SRCREV = "f8406b96363849c38204def56dfe7f10bc42c567"
 
-KV = "3.10.107"
-PV = "${KV}+git"
+LINUX_VERSION = "3.10.107"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 

--- a/meta-oneplus/recipes-kernel/linux/linux-oneplus-onyx_git.bb
+++ b/meta-oneplus/recipes-kernel/linux/linux-oneplus-onyx_git.bb
@@ -25,7 +25,7 @@ do_configure:prepend() {
 
 SRCREV = "772228294370696c428383eae99c124e17d3f6f3"
 
-KV = "3.4.0"
-PV = "${KV}+git"
+LINUX_VERSION = "3.4.0"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr

--- a/meta-volla/recipes-kernel/linux/linux-volla-yggdrasil_git.bb
+++ b/meta-volla/recipes-kernel/linux/linux-volla-yggdrasil_git.bb
@@ -51,8 +51,8 @@ do_configure:append() {
 
 SRCREV = "a3bc162aa456ec4f5d07f275ee97093e9087e602"
 
-KV = "4.4.243"
-PV = "${KV}+git"
+LINUX_VERSION = "4.4.243"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 

--- a/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-mido-halium_git.bb
+++ b/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-mido-halium_git.bb
@@ -25,8 +25,8 @@ do_configure:prepend() {
 
 SRCREV = "409f7adf4a862e439b5bec04739b67713e08b8ba"
 
-KV = "4.9.188"
-PV = "${KV}+git"
+LINUX_VERSION = "4.9.188"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 

--- a/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-mido_git.bb
+++ b/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-mido_git.bb
@@ -35,7 +35,6 @@ KBUILD_DEFCONFIG = ""
 
 S = "${WORKDIR}/git"
 
-KV = "${LINUX_VERSION}"
-PV = "${KV}+git"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr

--- a/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-oxygen_git.bb
+++ b/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-oxygen_git.bb
@@ -27,8 +27,8 @@ do_configure:prepend() {
 
 SRCREV = "649053b078b80d247d9cbf51c7fc97961a433101"
 
-KV = "3.18.31"
-PV = "${KV}+git"
+LINUX_VERSION = "3.18.31"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 

--- a/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-rosy_git.bb
+++ b/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-rosy_git.bb
@@ -32,8 +32,8 @@ SRCREV_kernel = "4dcf15ddaa13dd98e34aebd64371f94bdea41050"
 SRCREV_prima = "404995ddd576b4bad2ca7274f151fa2ed6243d5e"
 SRCREV_FORMAT = "kernel-prima"
 
-KV = "3.18.31"
-PV = "${KV}+git"
+LINUX_VERSION = "3.18.31"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 

--- a/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-sagit_git.bb
+++ b/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-sagit_git.bb
@@ -52,8 +52,8 @@ do_configure:append() {
 
 SRCREV = "917d5d898766594acef1bffc2f661db06032863b"
 
-KV = "4.4.249"
-PV = "${KV}+git"
+LINUX_VERSION = "4.4.249"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 

--- a/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-tissot_git.bb
+++ b/meta-xiaomi/recipes-kernel/linux/linux-xiaomi-tissot_git.bb
@@ -27,8 +27,8 @@ do_configure:prepend() {
 
 SRCREV = "adecf3d8664147a43f687ddd4a96c1e8cec52043"
 
-KV = "4.9.188"
-PV = "${KV}+git"
+LINUX_VERSION = "4.9.188"
+PV = "${LINUX_VERSION}+git"
 # for bumping PR bump MACHINE_KERNEL_PR in the machine config
 inherit machine_kernel_pr
 


### PR DESCRIPTION
* some recipes were using both, use just LINUX_VERSION for consistency

* current mix of versions:
meta-google/recipes-kernel/linux/linux-google-sargo_git.bb:LINUX_VERSION = "4.9.124"
meta-hp/recipes-kernel/linux/linux-hp-tenderloin-halium_git.bb:LINUX_VERSION = "3.4.113"
meta-hp/recipes-kernel/linux/linux-hp-tenderloin_git.bb:LINUX_VERSION = "5.19-rc7"
meta-huawei/recipes-kernel/linux/linux-huawei-angler_git.bb:LINUX_VERSION = "3.10.73"
meta-leeco/recipes-kernel/linux/linux-leeco-s2_git.bb:LINUX_VERSION = "3.10.84"
meta-lg/recipes-kernel/linux/linux-lg-hammerhead-halium_git.bb:LINUX_VERSION = "3.4.0"
meta-lg/recipes-kernel/linux/linux-lg-hammerhead_git.bb:LINUX_VERSION ?= "6.1"
meta-lg/recipes-kernel/linux/linux-lg-mako_git.bb:LINUX_VERSION = "3.4.113"
meta-motorola/recipes-kernel/linux/linux-motorola-athene_git.bb:LINUX_VERSION = "3.10.107"
meta-oneplus/recipes-kernel/linux/linux-oneplus-onyx_git.bb:LINUX_VERSION = "3.4.0"
meta-volla/recipes-kernel/linux/linux-volla-yggdrasil_git.bb:LINUX_VERSION = "4.4.243"
meta-xiaomi/recipes-kernel/linux/linux-xiaomi-mido-halium_git.bb:LINUX_VERSION = "4.9.188"
meta-xiaomi/recipes-kernel/linux/linux-xiaomi-mido_git.bb:LINUX_VERSION ?= "6.5.2"
meta-xiaomi/recipes-kernel/linux/linux-xiaomi-oxygen_git.bb:LINUX_VERSION = "3.18.31"
meta-xiaomi/recipes-kernel/linux/linux-xiaomi-rosy_git.bb:LINUX_VERSION = "3.18.31"
meta-xiaomi/recipes-kernel/linux/linux-xiaomi-sagit_git.bb:LINUX_VERSION = "4.4.249"
meta-xiaomi/recipes-kernel/linux/linux-xiaomi-tissot_git.bb:LINUX_VERSION = "4.9.188"

will need to find common denominator for each TUNE_PKGARCH to set OLDEST_KERNEL for the archs with MACHINE which has lower than 5.15 bumped in nanbield with:
https://git.openembedded.org/openembedded-core/commit/?h=master&id=feb8e3fb71131a414a2a9271832b4e16860301ea