### PR TITLE
initramfs-scripts-simple: improve recovery mode

### DIFF
--- a/meta-mainline/recipes-core/initrdscripts/initramfs-scripts-simple/init_functions.sh
+++ b/meta-mainline/recipes-core/initrdscripts/initramfs-scripts-simple/init_functions.sh
@@ -197,7 +197,7 @@ setup_usb_network_configfs() {
 	echo 250 > $CONFIGFS/g1/configs/c.$C/MaxPower 
 	ln -s $CONFIGFS/g1/functions/ecm.$N          $CONFIGFS/g1/configs/c.$C/
 
-    if grep -q bootmode=recovery /proc/cmdline; then
+    if grep -q bootmode=recovery /proc/cmdline || [ "$RECOVERYMODE" = "yes" ]; then
 		# recovery mode: expose sdcard
 		FILE=/dev/mmcblk0
 		


### PR DESCRIPTION
Detect recovery mode sooner, to be able to configure the mass-storage gadget properly.
Also, only try to start getty if luneos-recovery-ui failed. That way, if getty fails, a reboot won't be triggered until luneos-recovery-ui exits.